### PR TITLE
Update 4/24 spell to use correct variable names and add a comment

### DIFF
--- a/archive/2020-04-24-DssSpell.sol
+++ b/archive/2020-04-24-DssSpell.sol
@@ -63,8 +63,11 @@ contract SpellAction {
     address constant public BTCUSD = 0xe0F30cb149fAADC7247E953746Be9BbBB6B5751f;
 
     address constant public SET_ETHUSD = 0x97C3e595e8f80169266B5534e4d7A1bB58BB45ab;
-    address constant public DYDX_BTCUSD = 0xbf63446ecF3341e04c6569b226a57860B188edBc;
-    address constant public SET_BTCUSD = 0x538038E526517680735568f9C5342c6E68bbDA12;
+    // Lines 67 and 68 were modified after the spell was cast to prevent future confusion.
+    //  The mainnet spell transposed these values but the end result did not change.
+    //  We've edited this in post to properly label the addresses.
+    address constant public SET_BTCUSD = 0xbf63446ecF3341e04c6569b226a57860B188edBc;
+    address constant public DYDX_BTCUSD = 0x538038E526517680735568f9C5342c6E68bbDA12;
 
     // Many of the settings that change weekly rely on the rate accumulator
     // described at https://docs.makerdao.com/smart-contract-modules/rates-module


### PR DESCRIPTION
# Description

Discussed in planning. 
Post-fixes a transposition error between the Set and dYdX feed readers.
Adds a comment about the difference from mainnet.