### PR TITLE
SC-5970: Fix the archived spell that transposes DyDx and Set Protocol…

### DIFF
--- a/archive/2020-04-24-DssSpell.sol
+++ b/archive/2020-04-24-DssSpell.sol
@@ -66,8 +66,8 @@ contract SpellAction {
     // Lines 67 and 68 were modified after the spell was cast to prevent future confusion.
     //  The mainnet spell transposed these values but the end result did not change.
     //  We've edited this in post to properly label the addresses.
-    address constant public SET_BTCUSD = 0xbf63446ecF3341e04c6569b226a57860B188edBc;
-    address constant public DYDX_BTCUSD = 0x538038E526517680735568f9C5342c6E68bbDA12;
+    address constant public SET_BTCUSD = 0x538038E526517680735568f9C5342c6E68bbDA12;
+    address constant public DYDX_BTCUSD = 0xbf63446ecF3341e04c6569b226a57860B188edBc;
 
     // Many of the settings that change weekly rely on the rate accumulator
     // described at https://docs.makerdao.com/smart-contract-modules/rates-module


### PR DESCRIPTION
Fix the archived spell that transposes DyDx and Set Protocol addresses

# Description

# Contribution Checklist

- [ ] First commit title starts with 'SC-5970:'
- [ ] https://app.clubhouse.io/maker/story/5970/fix-the-archived-spell-that-transposes-dydx-and-set-protocol-addresses
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier
- [ ] Verify expiration (`4 days + 2 hours` monthly and `30 days` for the rest)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in changelog or known
- [ ] Deploy spell `SOLC_FLAGS="--optimize --optimize-runs=1" dapp --use solc:0.5.12 build && dapp create DssSpell --gas=2000000 --gas-price="$(seth --to-wei 420 "gwei")"`
- [ ] Verify `mainnet` contract on etherscan
- [ ] Change test to use mainnet spell address and deploy timestamp
- [ ] Keep `DssSpell.sol` and `DssSpell.t.sol` the same, but make a copy in `archive`
- [ ] `squash and merge` this PR
