### PR TITLE
SC-6609: 20201016 Exec - ETH-B Collateral Onboarding

### DIFF
--- a/archive/2020-10-16-DssSpell.sol
+++ b/archive/2020-10-16-DssSpell.sol
@@ -1,0 +1,210 @@
+// Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.5.12;
+
+import "lib/dss-interfaces/src/dapp/DSPauseAbstract.sol";
+import "lib/dss-interfaces/src/dss/CatAbstract.sol";
+import "lib/dss-interfaces/src/dss/FlipAbstract.sol";
+import "lib/dss-interfaces/src/dss/IlkRegistryAbstract.sol";
+import "lib/dss-interfaces/src/dss/GemJoinAbstract.sol";
+import "lib/dss-interfaces/src/dss/JugAbstract.sol";
+import "lib/dss-interfaces/src/dss/MedianAbstract.sol";
+import "lib/dss-interfaces/src/dss/OsmAbstract.sol";
+import "lib/dss-interfaces/src/dss/OsmMomAbstract.sol";
+import "lib/dss-interfaces/src/dss/SpotAbstract.sol";
+import "lib/dss-interfaces/src/dss/VatAbstract.sol";
+import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
+
+contract SpellAction {
+    // MAINNET ADDRESSES
+    //
+    // The contracts in this list should correspond to MCD core contracts, verify
+    //  against the current release list at:
+    //     https://changelog.makerdao.com/releases/mainnet/1.1.2/contracts.json
+
+    address constant MCD_VAT         = 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B;
+    address constant MCD_CAT         = 0xa5679C04fc3d9d8b0AaB1F0ab83555b301cA70Ea;
+    address constant MCD_JUG         = 0x19c0976f590D67707E62397C87829d896Dc0f1F1;
+    address constant MCD_SPOT        = 0x65C79fcB50Ca1594B025960e539eD7A9a6D434A3;
+    address constant MCD_POT         = 0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7;
+    address constant MCD_END         = 0xaB14d3CE3F733CACB76eC2AbE7d2fcb00c99F3d5;
+    address constant FLIPPER_MOM     = 0xc4bE7F74Ee3743bDEd8E0fA218ee5cf06397f472;
+    address constant OSM_MOM         = 0x76416A4d5190d071bfed309861527431304aA14f;
+    address constant ILK_REGISTRY    = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
+    address constant CHAINLOG        = 0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F;
+
+    // ETH-B specific addresses
+    address constant ETH            = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address constant MCD_JOIN_ETH_B = 0x08638eF1A205bE6762A8b935F5da9b700Cf7322c;
+    address constant MCD_FLIP_ETH_B = 0xD499d71bE9e9E5D236A07ac562F7B6CeacCa624c;
+    address constant PIP_ETH        = 0x81FE72B5A8d1A857d176C3E7d5Bd2679A9B85763; // OSM
+
+    // Decimals & precision
+    uint256 constant THOUSAND = 10 ** 3;
+    uint256 constant MILLION  = 10 ** 6;
+    uint256 constant WAD      = 10 ** 18;
+    uint256 constant RAY      = 10 ** 27;
+    uint256 constant RAD      = 10 ** 45;
+
+    // Many of the settings that change weekly rely on the rate accumulator
+    // described at https://docs.makerdao.com/smart-contract-modules/rates-module
+    // To check this yourself, use the following rate calculation (example 8%):
+    //
+    // $ bc -l <<< 'scale=27; e( l(1.08)/(60 * 60 * 24 * 365) )'
+    //
+    // A table of rates can be found at
+    //    https://ipfs.io/ipfs/QmefQMseb3AiTapiAKKexdKHig8wroKuZbmLtPLv4u2YwW
+    uint256 constant         SIX_PCT_RATE = 1000000001847694957439350562;
+
+    function execute() external {
+
+        /*** ETH-B Collateral Onboarding ***/
+
+        //   $ seth --to-bytes32 $(seth --from-ascii "ETH-B")
+        //   0x4554482d42000000000000000000000000000000000000000000000000000000
+        bytes32 ilk = "ETH-B";
+
+        // Sanity checks
+        require(GemJoinAbstract(MCD_JOIN_ETH_B).vat() == MCD_VAT, "join-vat-not-match");
+        require(GemJoinAbstract(MCD_JOIN_ETH_B).ilk() == ilk, "join-ilk-not-match");
+        require(GemJoinAbstract(MCD_JOIN_ETH_B).gem() == ETH, "join-gem-not-match");
+        require(GemJoinAbstract(MCD_JOIN_ETH_B).dec() == 18, "join-dec-not-match");
+        require(FlipAbstract(MCD_FLIP_ETH_B).vat() == MCD_VAT, "flip-vat-not-match");
+        require(FlipAbstract(MCD_FLIP_ETH_B).cat() == MCD_CAT, "flip-cat-not-match");
+        require(FlipAbstract(MCD_FLIP_ETH_B).ilk() == ilk, "flip-ilk-not-match");
+
+        // Add the new flip and join to the Chainlog
+        ChainlogAbstract(CHAINLOG).setAddress("MCD_JOIN_ETH_B", MCD_JOIN_ETH_B);
+        ChainlogAbstract(CHAINLOG).setAddress("MCD_FLIP_ETH_B", MCD_FLIP_ETH_B);
+        ChainlogAbstract(CHAINLOG).setVersion("1.1.3");
+
+        // Set the TOKEN PIP in the Spotter
+        SpotAbstract(MCD_SPOT).file(ilk, "pip", PIP_ETH);
+
+        // Set the TOKEN-LETTER Flipper in the Cat
+        CatAbstract(MCD_CAT).file(ilk, "flip", MCD_FLIP_ETH_B);
+
+        // Init TOKEN-LETTER ilk in Vat & Jug
+        VatAbstract(MCD_VAT).init(ilk);
+        JugAbstract(MCD_JUG).init(ilk);
+
+        // Allow TOKEN-LETTER Join to modify Vat registry
+        VatAbstract(MCD_VAT).rely(MCD_JOIN_ETH_B);
+        // Allow the TOKEN-LETTER Flipper to reduce the Cat litterbox on deal()
+        CatAbstract(MCD_CAT).rely(MCD_FLIP_ETH_B);
+        // Allow Cat to kick auctions in TOKEN-LETTER Flipper
+        FlipAbstract(MCD_FLIP_ETH_B).rely(MCD_CAT);
+        // Allow End to yank auctions in TOKEN-LETTER Flipper
+        FlipAbstract(MCD_FLIP_ETH_B).rely(MCD_END);
+        // Allow FlipperMom to access to the TOKEN-LETTER Flipper
+        FlipAbstract(MCD_FLIP_ETH_B).rely(FLIPPER_MOM);
+        // Disallow Cat to kick auctions in TOKEN-LETTER Flipper
+        // !!!!!!!! Only for certain collaterals that do not trigger liquidations like USDC-A)
+        //FlipperMomAbstract(FLIPPER_MOM).deny(MCD_FLIP_ETH_B);
+
+        // Allow OsmMom to access to the TOKEN Osm
+        // !!!!!!!! Only if PIP_TOKEN = Osm and hasn't been already relied due a previous deployed ilk
+        //OsmAbstract(PIP_TOKEN).rely(OSM_MOM);
+        // Whitelist Osm to read the Median data (only necessary if it is the first time the token is being added to an ilk)
+        // !!!!!!!! Only if PIP_TOKEN = Osm, its src is a Median and hasn't been already whitelisted due a previous deployed ilk
+        //MedianAbstract(OsmAbstract(PIP_TOKEN).src()).kiss(PIP_TOKEN);
+        // Whitelist Spotter to read the Osm data (only necessary if it is the first time the token is being added to an ilk)
+        // !!!!!!!! Only if PIP_TOKEN = Osm or PIP_TOKEN = Median and hasn't been already whitelisted due a previous deployed ilk
+        //OsmAbstract(PIP_TOKEN).kiss(MCD_SPOT);
+        // Whitelist End to read the Osm data (only necessary if it is the first time the token is being added to an ilk)
+        // !!!!!!!! Only if PIP_TOKEN = Osm or PIP_TOKEN = Median and hasn't been already whitelisted due a previous deployed ilk
+        //OsmAbstract(PIP_TOKEN).kiss(MCD_END);
+        // Set TOKEN Osm in the OsmMom for new ilk
+        // !!!!!!!! Only if PIP_TOKEN = Osm
+        OsmMomAbstract(OSM_MOM).setOsm(ilk, PIP_ETH);
+
+        // Set the global debt ceiling
+        VatAbstract(MCD_VAT).file("Line", 1476 * MILLION * RAD);
+        // Set the TOKEN-LETTER debt ceiling
+        VatAbstract(MCD_VAT).file(ilk, "line", 20 * MILLION * RAD);
+        // Set the TOKEN-LETTER dust
+        VatAbstract(MCD_VAT).file(ilk, "dust", 100 * RAD);
+        // Set the Lot size
+        CatAbstract(MCD_CAT).file(ilk, "dunk", 50 * THOUSAND * RAD);
+        // Set the TOKEN-LETTER liquidation penalty (e.g. 13% => X = 113)
+        CatAbstract(MCD_CAT).file(ilk, "chop", 113 * WAD / 100);
+        // Set the TOKEN-LETTER stability fee (e.g. 1% = 1000000000315522921573372069)
+        JugAbstract(MCD_JUG).file(ilk, "duty", SIX_PCT_RATE);
+        // Set the TOKEN-LETTER percentage between bids (e.g. 3% => X = 103)
+        FlipAbstract(MCD_FLIP_ETH_B).file("beg", 103 * WAD / 100);
+        // Set the TOKEN-LETTER time max time between bids
+        FlipAbstract(MCD_FLIP_ETH_B).file("ttl", 6 hours);
+        // Set the TOKEN-LETTER max auction duration to
+        FlipAbstract(MCD_FLIP_ETH_B).file("tau", 6 hours);
+        // Set the TOKEN-LETTER min collateralization ratio (e.g. 150% => X = 150)
+        SpotAbstract(MCD_SPOT).file(ilk, "mat", 130 * RAY / 100);
+
+        // Update TOKEN-LETTER spot value in Vat
+        SpotAbstract(MCD_SPOT).poke(ilk);
+
+        // Add new ilk to the IlkRegistry
+        IlkRegistryAbstract(ILK_REGISTRY).add(MCD_JOIN_ETH_B);
+    }
+}
+
+contract DssSpell {
+    DSPauseAbstract public pause =
+        DSPauseAbstract(0xbE286431454714F511008713973d3B053A2d38f3);
+    address         public action;
+    bytes32         public tag;
+    uint256         public eta;
+    bytes           public sig;
+    uint256         public expiration;
+    bool            public done;
+
+
+    // Provides a descriptive tag for bot consumption
+    // This should be modified weekly to provide a summary of the actions
+    // Hash: seth keccak -- "$(wget https://raw.githubusercontent.com/makerdao/community/6a97b8f1f145d86b2ea898826cd3232a5abc7c1d/governance/votes/Executive%20vote%20-%20October%2016%2C%202020.md -q -O - 2>/dev/null)"
+    string constant public description =
+        "2020-10-16 MakerDAO Executive Spell | Hash: 0xbaf455a1f3360f0d9f9941f79626e38344c5c58e96c4d2cf03461995fa1fe913";
+
+    constructor() public {
+        sig = abi.encodeWithSignature("execute()");
+        action = address(new SpellAction());
+        bytes32 _tag;
+        address _action = action;
+        assembly { _tag := extcodehash(_action) }
+        tag = _tag;
+        expiration = now + 30 days;
+    }
+
+    modifier officeHours {
+        uint day = (now / 1 days + 3) % 7;
+        require(day < 5, "Can only be cast on a weekday");
+        uint hour = now / 1 hours % 24;
+        require(hour >= 14 && hour < 21, "Outside office hours");
+        _;
+    }
+
+    function schedule() public {
+        require(now <= expiration, "This contract has expired");
+        require(eta == 0, "This spell has already been scheduled");
+        eta = now + DSPauseAbstract(pause).delay();
+        pause.plot(action, tag, sig, eta);
+    }
+
+    function cast() public officeHours {
+        require(!done, "spell-already-cast");
+        done = true;
+        pause.exec(action, tag, sig, eta);
+    }
+}

--- a/archive/2020-10-16-DssSpell.t.sol
+++ b/archive/2020-10-16-DssSpell.t.sol
@@ -1,0 +1,590 @@
+pragma solidity 0.5.12;
+
+import "ds-math/math.sol";
+import "ds-test/test.sol";
+import "lib/dss-interfaces/src/Interfaces.sol";
+import "./test/rates.sol";
+
+import {DssSpell, SpellAction} from "./DssSpell.sol";
+
+interface Hevm {
+    function warp(uint) external;
+    function store(address,bytes32,bytes32) external;
+}
+
+interface MedianizerV1Abstract {
+    function authority() external view returns (address);
+    function owner() external view returns (address);
+    function peek() external view returns (uint256, bool);
+    function poke() external;
+}
+
+contract DssSpellTest is DSTest, DSMath {
+    // populate with mainnet spell if needed
+    address constant MAINNET_SPELL = address(0x96F6CD23fd450D30A12eA0D14FCECc8aE8b4Bc25);
+    // this needs to be updated
+    uint256 constant SPELL_CREATED = 1602860406;
+
+    struct CollateralValues {
+        uint256 line;
+        uint256 dust;
+        uint256 chop;
+        uint256 dunk;
+        uint256 pct;
+        uint256 mat;
+        uint256 beg;
+        uint48 ttl;
+        uint48 tau;
+        uint256 liquidations;
+    }
+
+    struct SystemValues {
+        uint256 pot_dsr;
+        uint256 pot_dsrPct;
+        uint256 vat_Line;
+        uint256 pause_delay;
+        uint256 vow_wait;
+        uint256 vow_dump;
+        uint256 vow_sump;
+        uint256 vow_bump;
+        uint256 vow_hump;
+        uint256 cat_box;
+        uint256 ilk_count;
+        mapping (bytes32 => CollateralValues) collaterals;
+    }
+
+    SystemValues afterSpell;
+
+    Hevm hevm;
+    Rates rates;
+
+    // MAINNET ADDRESSES
+    DSPauseAbstract      pause = DSPauseAbstract(    0xbE286431454714F511008713973d3B053A2d38f3);
+    address         pauseProxy =                     0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB;
+    DSChiefAbstract      chief = DSChiefAbstract(    0x9eF05f7F6deB616fd37aC3c959a2dDD25A54E4F5);
+    VatAbstract            vat = VatAbstract(        0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B);
+    VowAbstract            vow = VowAbstract(        0xA950524441892A31ebddF91d3cEEFa04Bf454466);
+    CatAbstract            cat = CatAbstract(        0xa5679C04fc3d9d8b0AaB1F0ab83555b301cA70Ea);
+    PotAbstract            pot = PotAbstract(        0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
+    JugAbstract            jug = JugAbstract(        0x19c0976f590D67707E62397C87829d896Dc0f1F1);
+    SpotAbstract          spot = SpotAbstract(       0x65C79fcB50Ca1594B025960e539eD7A9a6D434A3);
+
+    DSTokenAbstract        gov = DSTokenAbstract(    0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
+    EndAbstract            end = EndAbstract(        0xaB14d3CE3F733CACB76eC2AbE7d2fcb00c99F3d5);
+    IlkRegistryAbstract    reg = IlkRegistryAbstract(0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24);
+
+    OsmMomAbstract      osmMom = OsmMomAbstract(     0x76416A4d5190d071bfed309861527431304aA14f);
+    FlipperMomAbstract flipMom = FlipperMomAbstract( 0xc4bE7F74Ee3743bDEd8E0fA218ee5cf06397f472);
+
+    ChainlogAbstract chainlog  = ChainlogAbstract(   0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
+
+    address    makerDeployer05 = 0xDa0FaB05039809e63C5D068c897c3e602fA97457;
+
+    DssSpell spell;
+
+    // CHEAT_CODE = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D
+    bytes20 constant CHEAT_CODE =
+        bytes20(uint160(uint256(keccak256('hevm cheat code'))));
+
+    uint256 constant HUNDRED    = 10 ** 2;
+    uint256 constant THOUSAND   = 10 ** 3;
+    uint256 constant MILLION    = 10 ** 6;
+    uint256 constant BILLION    = 10 ** 9;
+    uint256 constant WAD        = 10 ** 18;
+    uint256 constant RAY        = 10 ** 27;
+    uint256 constant RAD        = 10 ** 45;
+
+    // not provided in DSMath
+    function rpow(uint x, uint n, uint b) internal pure returns (uint z) {
+      assembly {
+        switch x case 0 {switch n case 0 {z := b} default {z := 0}}
+        default {
+          switch mod(n, 2) case 0 { z := b } default { z := x }
+          let half := div(b, 2)  // for rounding.
+          for { n := div(n, 2) } n { n := div(n,2) } {
+            let xx := mul(x, x)
+            if iszero(eq(div(xx, x), x)) { revert(0,0) }
+            let xxRound := add(xx, half)
+            if lt(xxRound, xx) { revert(0,0) }
+            x := div(xxRound, b)
+            if mod(n,2) {
+              let zx := mul(z, x)
+              if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) { revert(0,0) }
+              let zxRound := add(zx, half)
+              if lt(zxRound, zx) { revert(0,0) }
+              z := div(zxRound, b)
+            }
+          }
+        }
+      }
+    }
+    // 10^-5 (tenth of a basis point) as a RAY
+    uint256 TOLERANCE = 10 ** 22;
+
+    function yearlyYield(uint256 duty) public pure returns (uint256) {
+        return rpow(duty, (365 * 24 * 60 *60), RAY);
+    }
+
+    function expectedRate(uint256 percentValue) public pure returns (uint256) {
+        return (100000 + percentValue) * (10 ** 22);
+    }
+
+    function diffCalc(uint256 expectedRate_, uint256 yearlyYield_) public pure returns (uint256) {
+        return (expectedRate_ > yearlyYield_) ? expectedRate_ - yearlyYield_ : yearlyYield_ - expectedRate_;
+    }
+
+    function setUp() public {
+        hevm = Hevm(address(CHEAT_CODE));
+        rates = new Rates();
+
+        spell = MAINNET_SPELL != address(0) ? DssSpell(MAINNET_SPELL) : new DssSpell();
+
+        //
+        // Test for all system configuration changes
+        //
+        afterSpell = SystemValues({
+            pot_dsr: 1000000000000000000000000000,
+            pot_dsrPct: 0 * 1000,
+            vat_Line: 1476 * MILLION * RAD,
+            pause_delay: 12 * 60 * 60,
+            vow_wait: 561600,
+            vow_dump: 250 * WAD,
+            vow_sump: 50000 * RAD,
+            vow_bump: 10000 * RAD,
+            vow_hump: 2 * MILLION * RAD,
+            cat_box: 15 * MILLION * RAD,
+            ilk_count: 15
+        });
+
+        //
+        // Test for all collateral based changes here
+        //
+        afterSpell.collaterals["ETH-A"] = CollateralValues({
+            line:         540 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          2 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          150 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["ETH-B"] = CollateralValues({
+            line:         20 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          6 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          130 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["BAT-A"] = CollateralValues({
+            line:         10 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          4 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          150 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["USDC-A"] = CollateralValues({
+            line:         485 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          4 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          101 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          3 days,
+            liquidations: 0
+        });
+        afterSpell.collaterals["USDC-B"] = CollateralValues({
+            line:         30 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          50 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          120 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          3 days,
+            liquidations: 0
+        });
+        afterSpell.collaterals["WBTC-A"] = CollateralValues({
+            line:         120 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          4 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          150 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["TUSD-A"] = CollateralValues({
+            line:         135 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          4 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          101 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          3 days,
+            liquidations: 0
+        });
+        afterSpell.collaterals["KNC-A"] = CollateralValues({
+            line:         5 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          4 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          175 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["ZRX-A"] = CollateralValues({
+            line:         5 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          4 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          175 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["MANA-A"] = CollateralValues({
+            line:         1 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          12 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          175 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["USDT-A"] = CollateralValues({
+            line:         10 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          8 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          150 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["PAXUSD-A"] = CollateralValues({
+            line:         100 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          4 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          101 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 0
+        });
+        afterSpell.collaterals["COMP-A"] = CollateralValues({
+            line:         7 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          3 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          175 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["LRC-A"] = CollateralValues({
+            line:         3 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          3 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          175 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["LINK-A"] = CollateralValues({
+            line:         5 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          2 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          175 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+    }
+
+    // function scheduleWaitAndCastFailDay() public {
+    //     spell.schedule();
+
+    //     uint256 castTime = now + pause.delay();
+    //     uint256 day = (castTime / 1 days + 3) % 7;
+    //     if (day < 5) {
+    //         castTime += 5 days - day * 86400;
+    //     }
+
+    //     hevm.warp(castTime);
+    //     spell.cast();
+    // }
+
+    // function scheduleWaitAndCastFailEarly() public {
+    //     spell.schedule();
+
+    //     uint256 castTime = now + pause.delay() + 24 hours;
+    //     uint256 hour = castTime / 1 hours % 24;
+    //     if (hour >= 14) {
+    //         castTime -= hour * 3600 - 13 hours;
+    //     }
+
+    //     hevm.warp(castTime);
+    //     spell.cast();
+    // }
+
+    // function scheduleWaitAndCastFailLate() public {
+    //     spell.schedule();
+
+    //     uint256 castTime = now + pause.delay();
+    //     uint256 hour = castTime / 1 hours % 24;
+    //     if (hour < 21) {
+    //         castTime += 21 hours - hour * 3600;
+    //     }
+
+    //     hevm.warp(castTime);
+    //     spell.cast();
+    // }
+
+    function vote() private {
+        if (chief.hat() != address(spell)) {
+            hevm.store(
+                address(gov),
+                keccak256(abi.encode(address(this), uint256(1))),
+                bytes32(uint256(999999999999 ether))
+            );
+            gov.approve(address(chief), uint256(-1));
+            chief.lock(sub(gov.balanceOf(address(this)), 1 ether));
+
+            assertTrue(!spell.done());
+
+            address[] memory yays = new address[](1);
+            yays[0] = address(spell);
+
+            chief.vote(yays);
+            chief.lift(address(spell));
+        }
+        assertEq(chief.hat(), address(spell));
+    }
+
+    function scheduleWaitAndCast() public {
+        spell.schedule();
+
+        uint256 castTime = now + pause.delay();
+
+        uint256 day = (castTime / 1 days + 3) % 7;
+        if(day >= 5) {
+            castTime += 7 days - day * 86400;
+        }
+
+        uint256 hour = castTime / 1 hours % 24;
+        if (hour >= 21) {
+            castTime += 24 hours - hour * 3600 + 14 hours;
+        } else if (hour < 14) {
+            castTime += 14 hours - hour * 3600;
+        }
+
+        hevm.warp(castTime);
+        spell.cast();
+    }
+
+    function stringToBytes32(string memory source) public pure returns (bytes32 result) {
+        assembly {
+            result := mload(add(source, 32))
+        }
+    }
+
+    function checkSystemValues(SystemValues storage values) internal {
+        // dsr
+        assertEq(pot.dsr(), values.pot_dsr);
+        // make sure dsr is less than 100% APR
+        // bc -l <<< 'scale=27; e( l(2.00)/(60 * 60 * 24 * 365) )'
+        // 1000000021979553151239153027
+        assertTrue(
+            pot.dsr() >= RAY && pot.dsr() < 1000000021979553151239153027
+        );
+        assertTrue(diffCalc(expectedRate(values.pot_dsrPct), yearlyYield(values.pot_dsr)) <= TOLERANCE);
+
+        // Line
+        assertEq(vat.Line(), values.vat_Line);
+        assertTrue(
+            (vat.Line() >= RAD && vat.Line() < 100 * BILLION * RAD) ||
+            vat.Line() == 0
+        );
+
+        // Pause delay
+        assertEq(pause.delay(), values.pause_delay);
+
+        // wait
+        assertEq(vow.wait(), values.vow_wait);
+
+        // dump
+        assertEq(vow.dump(), values.vow_dump);
+        assertTrue(
+            (vow.dump() >= WAD && vow.dump() < 2 * THOUSAND * WAD) ||
+            vow.dump() == 0
+        );
+
+        // sump
+        assertEq(vow.sump(), values.vow_sump);
+        assertTrue(
+            (vow.sump() >= RAD && vow.sump() < 500 * THOUSAND * RAD) ||
+            vow.sump() == 0
+        );
+
+        // bump
+        assertEq(vow.bump(), values.vow_bump);
+        assertTrue(
+            (vow.bump() >= RAD && vow.bump() < HUNDRED * THOUSAND * RAD) ||
+            vow.bump() == 0
+        );
+
+        // hump
+        assertEq(vow.hump(), values.vow_hump);
+        assertTrue(
+            (vow.hump() >= RAD && vow.hump() < HUNDRED * MILLION * RAD) ||
+            vow.hump() == 0
+        );
+
+        // box
+        assertEq(cat.box(), values.cat_box);
+
+        // check number of ilks
+        assertEq(reg.count(), values.ilk_count);
+    }
+
+    function checkCollateralValues(bytes32 ilk, SystemValues storage values) internal {
+        (uint duty,)  = jug.ilks(ilk);
+
+        assertEq(duty, rates.rates(values.collaterals[ilk].pct / 10));
+        // make sure duty is less than 1000% APR
+        // bc -l <<< 'scale=27; e( l(10.00)/(60 * 60 * 24 * 365) )'
+        // 1000000073014496989316680335
+        assertTrue(duty >= RAY && duty < 1000000073014496989316680335);  // gt 0 and lt 1000%
+        assertTrue(diffCalc(expectedRate(values.collaterals[ilk].pct), yearlyYield(rates.rates(values.collaterals[ilk].pct / 10))) <= TOLERANCE);
+        assertTrue(values.collaterals[ilk].pct < THOUSAND * THOUSAND);   // check value lt 1000%
+
+        (,,, uint line, uint dust) = vat.ilks(ilk);
+        assertEq(line, values.collaterals[ilk].line);
+        assertTrue((line >= RAD && line < BILLION * RAD) || line == 0);  // eq 0 or gt eq 1 RAD and lt 1B
+        assertEq(dust, values.collaterals[ilk].dust);
+        assertTrue((dust >= RAD && dust < 10 * THOUSAND * RAD) || dust == 0); // eq 0 or gt eq 1 and lt 10k
+
+        (, uint chop, uint dunk) = cat.ilks(ilk);
+        assertEq(chop, values.collaterals[ilk].chop);
+        // make sure chop is less than 100%
+        assertTrue(chop >= WAD && chop < 2 * WAD);   // penalty gt eq 0% and lt 100%
+        assertEq(dunk, values.collaterals[ilk].dunk);
+        // put back in after LIQ-1.2
+        assertTrue(dunk >= RAD && dunk < MILLION * RAD);
+
+        (,uint mat) = spot.ilks(ilk);
+        assertEq(mat, values.collaterals[ilk].mat);
+        assertTrue(mat >= RAY && mat < 10 * RAY);    // cr eq 100% and lt 1000%
+
+        (address flipper,,) = cat.ilks(ilk);
+        FlipAbstract flip = FlipAbstract(flipper);
+        assertEq(uint(flip.beg()), values.collaterals[ilk].beg);
+        assertTrue(flip.beg() >= WAD && flip.beg() < 105 * WAD / 100);  // gt eq 0% and lt 5%
+        assertEq(uint(flip.ttl()), values.collaterals[ilk].ttl);
+        assertTrue(flip.ttl() >= 600 && flip.ttl() < 10 hours);         // gt eq 10 minutes and lt 10 hours
+        assertEq(uint(flip.tau()), values.collaterals[ilk].tau);
+        assertTrue(flip.tau() >= 600 && flip.tau() <= 3 days);          // gt eq 10 minutes and lt eq 3 days
+
+        assertEq(flip.wards(address(cat)), values.collaterals[ilk].liquidations);  // liquidations == 1 => on
+        assertEq(flip.wards(address(makerDeployer05)), 0); // Check deployer denied
+        assertEq(flip.wards(address(pauseProxy)), 1); // Check pause_proxy ward
+
+        GemJoinAbstract join = GemJoinAbstract(reg.join(ilk));
+        assertEq(join.wards(address(makerDeployer05)), 0); // Check deployer denied
+        assertEq(join.wards(address(pauseProxy)), 1); // Check pause_proxy ward
+    }
+
+    // function testFailWrongDay() public {
+    //     vote();
+    //     scheduleWaitAndCastFailDay();
+    // }
+
+    // function testFailTooEarly() public {
+    //     vote();
+    //     scheduleWaitAndCastFailEarly();
+    // }
+
+    // function testFailTooLate() public {
+    //     vote();
+    //     scheduleWaitAndCastFailLate();
+    // }
+
+    function testChainlogAdditions() public {
+
+        assertEq(chainlog.count(), 89);
+
+        vote();
+        scheduleWaitAndCast();
+        assertTrue(spell.done());
+
+        assertEq(chainlog.count(), 91);
+        assertEq(chainlog.version(), "1.1.3");
+        assertEq(chainlog.getAddress("MCD_JOIN_ETH_B"), 0x08638eF1A205bE6762A8b935F5da9b700Cf7322c);
+        assertEq(chainlog.getAddress("MCD_FLIP_ETH_B"), 0xD499d71bE9e9E5D236A07ac562F7B6CeacCa624c);
+    }
+
+    function testSpellIsCast() public {
+        string memory description = new DssSpell().description();
+        assertTrue(bytes(description).length > 0);
+        // DS-Test can't handle strings directly, so cast to a bytes32.
+        assertEq(stringToBytes32(spell.description()),
+                stringToBytes32(description));
+
+        if(address(spell) != address(MAINNET_SPELL)) {
+            assertEq(spell.expiration(), (now + 30 days));
+        } else {
+            assertEq(spell.expiration(), (SPELL_CREATED + 30 days));
+        }
+
+        vote();
+        scheduleWaitAndCast();
+        assertTrue(spell.done());
+
+        checkSystemValues(afterSpell);
+
+        bytes32[] memory ilks = reg.list();
+        for(uint i = 0; i < ilks.length; i++) {
+            checkCollateralValues(ilks[i],  afterSpell);
+        }
+    }
+}

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -187,13 +187,13 @@ contract DssSpell {
         expiration = now + 30 days;
     }
 
-    // modifier officeHours {
-    //     uint day = (now / 1 days + 3) % 7;
-    //     require(day < 5, "Can only be cast on a weekday");
-    //     uint hour = now / 1 hours % 24;
-    //     require(hour >= 14 && hour < 21, "Outside office hours");
-    //     _;
-    // }
+    modifier officeHours {
+        uint day = (now / 1 days + 3) % 7;
+        require(day < 5, "Can only be cast on a weekday");
+        uint hour = now / 1 hours % 24;
+        require(hour >= 14 && hour < 21, "Outside office hours");
+        _;
+    }
 
     function schedule() public {
         require(now <= expiration, "This contract has expired");
@@ -202,7 +202,7 @@ contract DssSpell {
         pause.plot(action, tag, sig, eta);
     }
 
-    function cast() public {
+    function cast() public officeHours {
         require(!done, "spell-already-cast");
         done = true;
         pause.exec(action, tag, sig, eta);

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -173,9 +173,9 @@ contract DssSpell {
 
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
-    // Hash: seth keccak -- "$(wget https://raw.githubusercontent.com/makerdao/community/<tbd> -q -O - 2>/dev/null)"
+    // Hash: seth keccak -- "$(wget https://raw.githubusercontent.com/makerdao/community/6a97b8f1f145d86b2ea898826cd3232a5abc7c1d/governance/votes/Executive%20vote%20-%20October%2016%2C%202020.md -q -O - 2>/dev/null)"
     string constant public description =
-        "2020-10-16 MakerDAO Executive Spell | Hash: 0x0";
+        "2020-10-16 MakerDAO Executive Spell | Hash: 0xbaf455a1f3360f0d9f9941f79626e38344c5c58e96c4d2cf03461995fa1fe913";
 
     constructor() public {
         sig = abi.encodeWithSignature("execute()");

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -26,6 +26,7 @@ import "lib/dss-interfaces/src/dss/OsmAbstract.sol";
 import "lib/dss-interfaces/src/dss/OsmMomAbstract.sol";
 import "lib/dss-interfaces/src/dss/SpotAbstract.sol";
 import "lib/dss-interfaces/src/dss/VatAbstract.sol";
+import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
 
 contract SpellAction {
     // MAINNET ADDRESSES
@@ -43,6 +44,7 @@ contract SpellAction {
     address constant FLIPPER_MOM     = 0xc4bE7F74Ee3743bDEd8E0fA218ee5cf06397f472;
     address constant OSM_MOM         = 0x76416A4d5190d071bfed309861527431304aA14f;
     address constant ILK_REGISTRY    = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
+    address constant CHAINLOG        = 0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F;
 
     // ETH-B specific addresses
     address constant ETH            = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
@@ -83,6 +85,11 @@ contract SpellAction {
         require(FlipAbstract(MCD_FLIP_ETH_B).vat() == MCD_VAT, "flip-vat-not-match");
         require(FlipAbstract(MCD_FLIP_ETH_B).cat() == MCD_CAT, "flip-cat-not-match");
         require(FlipAbstract(MCD_FLIP_ETH_B).ilk() == ilk, "flip-ilk-not-match");
+
+        // Add the new flip and join to the Chainlog
+        ChainlogAbstract(CHAINLOG).setAddress("MCD_JOIN_ETH_B", MCD_JOIN_ETH_B);
+        ChainlogAbstract(CHAINLOG).setAddress("MCD_FLIP_ETH_B", MCD_FLIP_ETH_B);
+        ChainlogAbstract(CHAINLOG).setVersion("1.1.3");
 
         // Set the TOKEN PIP in the Spotter
         SpotAbstract(MCD_SPOT).file(ilk, "pip", PIP_ETH);

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -76,6 +76,8 @@ contract DssSpellTest is DSTest, DSMath {
     OsmMomAbstract      osmMom = OsmMomAbstract(     0x76416A4d5190d071bfed309861527431304aA14f);
     FlipperMomAbstract flipMom = FlipperMomAbstract( 0xc4bE7F74Ee3743bDEd8E0fA218ee5cf06397f472);
 
+    ChainlogAbstract chainlog  = ChainlogAbstract(   0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
+
     address    makerDeployer05 = 0xDa0FaB05039809e63C5D068c897c3e602fA97457;
 
     DssSpell spell;
@@ -546,6 +548,20 @@ contract DssSpellTest is DSTest, DSMath {
     //     vote();
     //     scheduleWaitAndCastFailLate();
     // }
+
+    function testChainlogAdditions() public {
+
+        assertEq(chainlog.count(), 89);
+
+        vote();
+        scheduleWaitAndCast();
+        assertTrue(spell.done());
+
+        assertEq(chainlog.count(), 91);
+        assertEq(chainlog.version(), "1.1.3");
+        assertEq(chainlog.getAddress("MCD_JOIN_ETH_B"), 0x08638eF1A205bE6762A8b935F5da9b700Cf7322c);
+        assertEq(chainlog.getAddress("MCD_FLIP_ETH_B"), 0xD499d71bE9e9E5D236A07ac562F7B6CeacCa624c);
+    }
 
     function testSpellIsCast() public {
         string memory description = new DssSpell().description();

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -406,17 +406,17 @@ contract DssSpellTest is DSTest, DSMath {
 
         uint256 castTime = now + pause.delay();
 
-        // uint256 day = (castTime / 1 days + 3) % 7;
-        // if(day >= 5) {
-        //     castTime += 7 days - day * 86400;
-        // }
+        uint256 day = (castTime / 1 days + 3) % 7;
+        if(day >= 5) {
+            castTime += 7 days - day * 86400;
+        }
 
-        // uint256 hour = castTime / 1 hours % 24;
-        // if (hour >= 21) {
-        //     castTime += 24 hours - hour * 3600 + 14 hours;
-        // } else if (hour < 14) {
-        //     castTime += 14 hours - hour * 3600;
-        // }
+        uint256 hour = castTime / 1 hours % 24;
+        if (hour >= 21) {
+            castTime += 24 hours - hour * 3600 + 14 hours;
+        } else if (hour < 14) {
+            castTime += 14 hours - hour * 3600;
+        }
 
         hevm.warp(castTime);
         spell.cast();

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -76,8 +76,7 @@ contract DssSpellTest is DSTest, DSMath {
     OsmMomAbstract      osmMom = OsmMomAbstract(     0x76416A4d5190d071bfed309861527431304aA14f);
     FlipperMomAbstract flipMom = FlipperMomAbstract( 0xc4bE7F74Ee3743bDEd8E0fA218ee5cf06397f472);
 
-    GemAbstract           tusd = GemAbstract(        0x0000000000085d4780B73119b644AE5ecd22b376);
-    GemJoinAbstract  joinTUSDA = GemJoinAbstract(    0x4454aF7C8bb9463203b66C816220D41ED7837f44);
+    address    makerDeployer05 = 0xDa0FaB05039809e63C5D068c897c3e602fA97457;
 
     DssSpell spell;
 
@@ -525,6 +524,12 @@ contract DssSpellTest is DSTest, DSMath {
         assertTrue(flip.tau() >= 600 && flip.tau() <= 3 days);          // gt eq 10 minutes and lt eq 3 days
 
         assertEq(flip.wards(address(cat)), values.collaterals[ilk].liquidations);  // liquidations == 1 => on
+        assertEq(flip.wards(address(makerDeployer05)), 0); // Check deployer denied
+        assertEq(flip.wards(address(pauseProxy)), 1); // Check pause_proxy ward
+
+        GemJoinAbstract join = GemJoinAbstract(reg.join(ilk));
+        assertEq(join.wards(address(makerDeployer05)), 0); // Check deployer denied
+        assertEq(join.wards(address(pauseProxy)), 1); // Check pause_proxy ward
     }
 
     // function testFailWrongDay() public {

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -144,7 +144,7 @@ contract DssSpellTest is DSTest, DSMath {
         afterSpell = SystemValues({
             pot_dsr: 1000000000000000000000000000,
             pot_dsrPct: 0 * 1000,
-            vat_Line: 1456 * MILLION * RAD,
+            vat_Line: 1476 * MILLION * RAD,
             pause_delay: 12 * 60 * 60,
             vow_wait: 561600,
             vow_dump: 250 * WAD,
@@ -152,7 +152,7 @@ contract DssSpellTest is DSTest, DSMath {
             vow_bump: 10000 * RAD,
             vow_hump: 2 * MILLION * RAD,
             cat_box: 15 * MILLION * RAD,
-            ilk_count: 14
+            ilk_count: 15
         });
 
         //
@@ -165,6 +165,18 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         113 * WAD / 100,
             dunk:         50 * THOUSAND * RAD,
             mat:          150 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["ETH-B"] = CollateralValues({
+            line:         20 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          6 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         50 * THOUSAND * RAD,
+            mat:          130 * RAY / 100,
             beg:          103 * WAD / 100,
             ttl:          6 hours,
             tau:          6 hours,

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -21,9 +21,9 @@ interface MedianizerV1Abstract {
 
 contract DssSpellTest is DSTest, DSMath {
     // populate with mainnet spell if needed
-    address constant MAINNET_SPELL = address(0);
+    address constant MAINNET_SPELL = address(0x96F6CD23fd450D30A12eA0D14FCECc8aE8b4Bc25);
     // this needs to be updated
-    uint256 constant SPELL_CREATED = 1601653978;
+    uint256 constant SPELL_CREATED = 1602860406;
 
     struct CollateralValues {
         uint256 line;


### PR DESCRIPTION
# Description

https://app.clubhouse.io/maker/story/6609/add-eth-b-collateral-mainnet

* Adds ETH-B collateral with parameters defined in the [polling proposal](https://vote.makerdao.com/polling-proposal/qmzvcsx9lkpejp8xpxsvkvvfot8anarmdq17afjdbbu3wu)
* Adds some tests to ensure deployer05 has been denied and pauseproxy has been relied.
* NOTE: I've left the unused functions in the collateral onboarding script in here but commented out. On the one hand, I think it's important to keep our onboarding heuristic in tact so that people can see that the decisions were deliberate, but on the other hand we may not want to display the commented out code. I'm not particularly committed to keeping the commented code in there, but if we do remove it we should put a comment with a link to the script template so that others looking to do a collateral onboarding know where to look instead of pulling the code from here.

# Contribution Checklist

- [X] First commit title starts with 'SC-**TICKET_NUMBER**:'
- [X] Link to clubhouse ticket
- [x] Code approved
- [x] Tests approved
- [x] CI Tests pass

# Checklist

- [x] Every contract variable/method declared as public/external private/internal
- [x] Consider if this PR needs the `officeHours` modifier
- [x] Verify expiration (`4 days + 2 hours` monthly and `30 days` for the rest)
- [x] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [x] Validate all addresses used are in changelog or known
- [x] Deploy spell `SOLC_FLAGS="--optimize --optimize-runs=1" dapp --use solc:0.5.12 build && dapp create DssSpell --gas=XXX --gas-price="$(seth --to-wei YYY "gwei")"`
- [x] Verify `mainnet` contract on etherscan
- [x] Change test to use mainnet spell address and deploy timestamp
- [x] Keep `DssSpell.sol` and `DssSpell.t.sol` the same, but make a copy in `archive`
- [ ] `squash and merge` this PR
