### PR TITLE
SC-6623: 2020-10-03 Executive

### DIFF
--- a/archive/2020-10-23-DssSpell.sol
+++ b/archive/2020-10-23-DssSpell.sol
@@ -1,0 +1,115 @@
+// Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.5.12;
+
+import "lib/dss-interfaces/src/dapp/DSPauseAbstract.sol";
+import "lib/dss-interfaces/src/dss/MedianAbstract.sol";
+import "lib/dss-interfaces/src/dss/OsmAbstract.sol";
+import "lib/dss-interfaces/src/dss/VowAbstract.sol";
+
+contract SpellAction {
+    // MAINNET ADDRESSES
+    //
+    // The contracts in this list should correspond to MCD core contracts, verify
+    //  against the current release list at:
+    //     https://changelog.makerdao.com/releases/mainnet/1.1.3/contracts.json
+
+    address constant MCD_VOW       = 0xA950524441892A31ebddF91d3cEEFa04Bf454466;
+    address constant ETHUSD_MEDIAN = 0x64DE91F5A373Cd4c28de3600cB34C7C6cE410C85;
+    address constant ETHUSD_OSM    = 0x81FE72B5A8d1A857d176C3E7d5Bd2679A9B85763;
+
+    // spell-specific addresses
+
+    // B Protocol
+    address constant B_PROTOCOL_BUD_CONNECTOR = 0x2325aa20DEAa9770a978f1dc7C073589ffC79DC3;
+
+    // Decimals & precision
+    uint256 constant THOUSAND = 10 ** 3;
+    uint256 constant MILLION  = 10 ** 6;
+    uint256 constant WAD      = 10 ** 18;
+    uint256 constant RAY      = 10 ** 27;
+    uint256 constant RAD      = 10 ** 45;
+
+    // Many of the settings that change weekly rely on the rate accumulator
+    // described at https://docs.makerdao.com/smart-contract-modules/rates-module
+    // To check this yourself, use the following rate calculation (example 8%):
+    //
+    // $ bc -l <<< 'scale=27; e( l(1.08)/(60 * 60 * 24 * 365) )'
+    //
+    // A table of rates can be found at
+    //    https://ipfs.io/ipfs/QmefQMseb3AiTapiAKKexdKHig8wroKuZbmLtPLv4u2YwW
+
+    // No rate chagnes this week.
+
+    function execute() external {
+        // Set the surplus buffer to 4,000,000 DAI
+        VowAbstract(MCD_VOW).file("hump", 4 * MILLION * RAD);
+
+        // Whitelist B Protocol to access the ETHUSD Medianizer
+        MedianAbstract(ETHUSD_MEDIAN).kiss(B_PROTOCOL_BUD_CONNECTOR);
+
+        // Whitelist B Protocol to access the ETHUSD OSM
+        OsmAbstract(ETHUSD_OSM).kiss(B_PROTOCOL_BUD_CONNECTOR);
+    }
+}
+
+contract DssSpell {
+    DSPauseAbstract public pause =
+        DSPauseAbstract(0xbE286431454714F511008713973d3B053A2d38f3);
+    address         public action;
+    bytes32         public tag;
+    uint256         public eta;
+    bytes           public sig;
+    uint256         public expiration;
+    bool            public done;
+
+    // Provides a descriptive tag for bot consumption
+    // This should be modified weekly to provide a summary of the actions
+    // Hash: seth keccak -- "$(wget https://raw.githubusercontent.com/makerdao/community/10f4fb51d9d6b292d7ffd3f852cbbc97bd920e84/governance/votes/Executive%20vote%20-%20October%2023%2C%202020.md -q -O - 2>/dev/null)"
+    string constant public description =
+        "2020-10-23 MakerDAO Executive Spell | Hash: 0x500dd161a37646be178bb4a33a1bbef78443f5e60aa660d6d3b480791326c964";
+
+    constructor() public {
+        sig = abi.encodeWithSignature("execute()");
+        action = address(new SpellAction());
+        bytes32 _tag;
+        address _action = action;
+        assembly { _tag := extcodehash(_action) }
+        tag = _tag;
+        expiration = now + 30 days;
+    }
+
+    modifier officeHours {
+        uint day = (now / 1 days + 3) % 7;
+        require(day < 5, "Can only be cast on a weekday");
+        uint hour = now / 1 hours % 24;
+        require(hour >= 14 && hour < 21, "Outside office hours");
+        _;
+    }
+
+    function schedule() public {
+        require(now <= expiration, "This contract has expired");
+        require(eta == 0, "This spell has already been scheduled");
+        eta = now + DSPauseAbstract(pause).delay();
+        pause.plot(action, tag, sig, eta);
+    }
+
+    function cast() public /* officeHours */ {
+        require(!done, "spell-already-cast");
+        done = true;
+        pause.exec(action, tag, sig, eta);
+    }
+}

--- a/archive/2020-10-23-DssSpell.t.sol
+++ b/archive/2020-10-23-DssSpell.t.sol
@@ -1,0 +1,614 @@
+pragma solidity 0.5.12;
+
+import "ds-math/math.sol";
+import "ds-test/test.sol";
+import "lib/dss-interfaces/src/Interfaces.sol";
+import "./test/rates.sol";
+
+import {DssSpell, SpellAction} from "./DssSpell.sol";
+
+interface Hevm {
+    function warp(uint) external;
+    function store(address,bytes32,bytes32) external;
+}
+
+interface MedianizerV1Abstract {
+    function authority() external view returns (address);
+    function owner() external view returns (address);
+    function peek() external view returns (uint256, bool);
+    function poke() external;
+}
+
+contract DssSpellTest is DSTest, DSMath {
+    // populate with mainnet spell if needed
+    address constant MAINNET_SPELL = address(0xb04A29de213411DDb7196eD1327b3B6144893E59);
+    // this needs to be updated
+    uint256 constant SPELL_CREATED = 1603464858;
+
+    struct CollateralValues {
+        uint256 line;
+        uint256 dust;
+        uint256 chop;
+        uint256 dunk;
+        uint256 pct;
+        uint256 mat;
+        uint256 beg;
+        uint48 ttl;
+        uint48 tau;
+        uint256 liquidations;
+    }
+
+    struct SystemValues {
+        uint256 dsr_rate;
+        uint256 vat_Line;
+        uint256 pause_delay;
+        uint256 vow_wait;
+        uint256 vow_dump;
+        uint256 vow_sump;
+        uint256 vow_bump;
+        uint256 vow_hump;
+        uint256 cat_box;
+        uint256 ilk_count;
+        mapping (bytes32 => CollateralValues) collaterals;
+    }
+
+    SystemValues afterSpell;
+
+    Hevm hevm;
+    Rates rates;
+
+    // MAINNET ADDRESSES
+    DSPauseAbstract      pause = DSPauseAbstract(    0xbE286431454714F511008713973d3B053A2d38f3);
+    address         pauseProxy =                     0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB;
+    DSChiefAbstract      chief = DSChiefAbstract(    0x9eF05f7F6deB616fd37aC3c959a2dDD25A54E4F5);
+    VatAbstract            vat = VatAbstract(        0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B);
+    VowAbstract            vow = VowAbstract(        0xA950524441892A31ebddF91d3cEEFa04Bf454466);
+    CatAbstract            cat = CatAbstract(        0xa5679C04fc3d9d8b0AaB1F0ab83555b301cA70Ea);
+    PotAbstract            pot = PotAbstract(        0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
+    JugAbstract            jug = JugAbstract(        0x19c0976f590D67707E62397C87829d896Dc0f1F1);
+    SpotAbstract          spot = SpotAbstract(       0x65C79fcB50Ca1594B025960e539eD7A9a6D434A3);
+
+    DSTokenAbstract        gov = DSTokenAbstract(    0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2);
+    EndAbstract            end = EndAbstract(        0xaB14d3CE3F733CACB76eC2AbE7d2fcb00c99F3d5);
+    IlkRegistryAbstract    reg = IlkRegistryAbstract(0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24);
+
+    OsmMomAbstract      osmMom = OsmMomAbstract(     0x76416A4d5190d071bfed309861527431304aA14f);
+    FlipperMomAbstract flipMom = FlipperMomAbstract( 0xc4bE7F74Ee3743bDEd8E0fA218ee5cf06397f472);
+
+    ChainlogAbstract chainlog  = ChainlogAbstract(   0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
+
+    address    makerDeployer05 = 0xDa0FaB05039809e63C5D068c897c3e602fA97457;
+
+    DssSpell spell;
+
+    // CHEAT_CODE = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D
+    bytes20 constant CHEAT_CODE =
+        bytes20(uint160(uint256(keccak256('hevm cheat code'))));
+
+    uint256 constant HUNDRED    = 10 ** 2;
+    uint256 constant THOUSAND   = 10 ** 3;
+    uint256 constant MILLION    = 10 ** 6;
+    uint256 constant BILLION    = 10 ** 9;
+    uint256 constant WAD        = 10 ** 18;
+    uint256 constant RAY        = 10 ** 27;
+    uint256 constant RAD        = 10 ** 45;
+
+    event Debug(uint256 index, uint256 val);
+    event Debug(uint256 index, address addr);
+    event Debug(uint256 index, bytes32 what);
+
+    // not provided in DSMath
+    function rpow(uint x, uint n, uint b) internal pure returns (uint z) {
+      assembly {
+        switch x case 0 {switch n case 0 {z := b} default {z := 0}}
+        default {
+          switch mod(n, 2) case 0 { z := b } default { z := x }
+          let half := div(b, 2)  // for rounding.
+          for { n := div(n, 2) } n { n := div(n,2) } {
+            let xx := mul(x, x)
+            if iszero(eq(div(xx, x), x)) { revert(0,0) }
+            let xxRound := add(xx, half)
+            if lt(xxRound, xx) { revert(0,0) }
+            x := div(xxRound, b)
+            if mod(n,2) {
+              let zx := mul(z, x)
+              if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) { revert(0,0) }
+              let zxRound := add(zx, half)
+              if lt(zxRound, zx) { revert(0,0) }
+              z := div(zxRound, b)
+            }
+          }
+        }
+      }
+    }
+    // 10^-5 (tenth of a basis point) as a RAY
+    uint256 TOLERANCE = 10 ** 22;
+
+    function yearlyYield(uint256 duty) public pure returns (uint256) {
+        return rpow(duty, (365 * 24 * 60 *60), RAY);
+    }
+
+    function expectedRate(uint256 percentValue) public pure returns (uint256) {
+        return (10000 + percentValue) * (10 ** 23);
+    }
+
+    function diffCalc(uint256 expectedRate_, uint256 yearlyYield_) public pure returns (uint256) {
+        return (expectedRate_ > yearlyYield_) ? expectedRate_ - yearlyYield_ : yearlyYield_ - expectedRate_;
+    }
+
+    function setUp() public {
+        hevm = Hevm(address(CHEAT_CODE));
+        rates = new Rates();
+
+        spell = MAINNET_SPELL != address(0) ? DssSpell(MAINNET_SPELL) : new DssSpell();
+
+        //
+        // Test for all system configuration changes
+        //
+        afterSpell = SystemValues({
+            dsr_rate:     0,               // In basis points
+            vat_Line:     1476 * MILLION,  // In whole Dai units
+            pause_delay:  12 hours,        // In seconds
+            vow_wait:     156 hours,       // In seconds
+            vow_dump:     250,             // In whole Dai units
+            vow_sump:     50000,           // In whole Dai units
+            vow_bump:     10000,           // In whole Dai units
+            vow_hump:     4 * MILLION,     // In whole Dai units
+            cat_box:      15 * MILLION,    // In whole Dai units
+            ilk_count:    15               // Num expected in system
+        });
+
+        //
+        // Test for all collateral based changes here
+        //
+        afterSpell.collaterals["ETH-A"] = CollateralValues({
+            line:         540 * MILLION,   // In whole Dai units
+            dust:         100,             // In whole Dai units
+            pct:          200,             // In basis points
+            chop:         1300,            // In basis points
+            dunk:         50 * THOUSAND,   // In whole Dai units
+            mat:          15000,           // In basis points
+            beg:          300,             // In basis points
+            ttl:          6 hours,         // In seconds
+            tau:          6 hours,         // In seconds
+            liquidations: 1                // 1 if enabled
+        });
+        afterSpell.collaterals["ETH-B"] = CollateralValues({
+            line:         20 * MILLION,
+            dust:         100,
+            pct:          600,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          13000,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["BAT-A"] = CollateralValues({
+            line:         10 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          15000,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["USDC-A"] = CollateralValues({
+            line:         485 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          10100,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          3 days,
+            liquidations: 0
+        });
+        afterSpell.collaterals["USDC-B"] = CollateralValues({
+            line:         30 * MILLION,
+            dust:         100,
+            pct:          5000,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          12000,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          3 days,
+            liquidations: 0
+        });
+        afterSpell.collaterals["WBTC-A"] = CollateralValues({
+            line:         120 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          15000,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["TUSD-A"] = CollateralValues({
+            line:         135 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          10100,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          3 days,
+            liquidations: 0
+        });
+        afterSpell.collaterals["KNC-A"] = CollateralValues({
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          17500,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["ZRX-A"] = CollateralValues({
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          17500,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["MANA-A"] = CollateralValues({
+            line:         1 * MILLION,
+            dust:         100,
+            pct:          1200,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          17500,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["USDT-A"] = CollateralValues({
+            line:         10 * MILLION,
+            dust:         100,
+            pct:          800,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          15000,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["PAXUSD-A"] = CollateralValues({
+            line:         100 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          10100,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 0
+        });
+        afterSpell.collaterals["COMP-A"] = CollateralValues({
+            line:         7 * MILLION,
+            dust:         100,
+            pct:          300,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          17500,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["LRC-A"] = CollateralValues({
+            line:         3 * MILLION,
+            dust:         100,
+            pct:          300,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          17500,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["LINK-A"] = CollateralValues({
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          200,
+            chop:         1300,
+            dunk:         50 * THOUSAND,
+            mat:          17500,
+            beg:          300,
+            ttl:          6 hours,
+            tau:          6 hours,
+            liquidations: 1
+        });
+    }
+
+    // function scheduleWaitAndCastFailDay() public {
+    //     spell.schedule();
+
+    //     uint256 castTime = now + pause.delay();
+    //     uint256 day = (castTime / 1 days + 3) % 7;
+    //     if (day < 5) {
+    //         castTime += 5 days - day * 86400;
+    //     }
+
+    //     hevm.warp(castTime);
+    //     spell.cast();
+    // }
+
+    // function scheduleWaitAndCastFailEarly() public {
+    //     spell.schedule();
+
+    //     uint256 castTime = now + pause.delay() + 24 hours;
+    //     uint256 hour = castTime / 1 hours % 24;
+    //     if (hour >= 14) {
+    //         castTime -= hour * 3600 - 13 hours;
+    //     }
+
+    //     hevm.warp(castTime);
+    //     spell.cast();
+    // }
+
+    // function scheduleWaitAndCastFailLate() public {
+    //     spell.schedule();
+
+    //     uint256 castTime = now + pause.delay();
+    //     uint256 hour = castTime / 1 hours % 24;
+    //     if (hour < 21) {
+    //         castTime += 21 hours - hour * 3600;
+    //     }
+
+    //     hevm.warp(castTime);
+    //     spell.cast();
+    // }
+
+    function vote() private {
+        if (chief.hat() != address(spell)) {
+            hevm.store(
+                address(gov),
+                keccak256(abi.encode(address(this), uint256(1))),
+                bytes32(uint256(999999999999 ether))
+            );
+            gov.approve(address(chief), uint256(-1));
+            chief.lock(sub(gov.balanceOf(address(this)), 1 ether));
+
+            assertTrue(!spell.done());
+
+            address[] memory yays = new address[](1);
+            yays[0] = address(spell);
+
+            chief.vote(yays);
+            chief.lift(address(spell));
+        }
+        assertEq(chief.hat(), address(spell));
+    }
+
+    function scheduleWaitAndCast() public {
+        spell.schedule();
+
+        uint256 castTime = now + pause.delay();
+
+        uint256 day = (castTime / 1 days + 3) % 7;
+        if(day >= 5) {
+            castTime += 7 days - day * 86400;
+        }
+
+        uint256 hour = castTime / 1 hours % 24;
+        if (hour >= 21) {
+            castTime += 24 hours - hour * 3600 + 14 hours;
+        } else if (hour < 14) {
+            castTime += 14 hours - hour * 3600;
+        }
+
+        hevm.warp(castTime);
+        spell.cast();
+    }
+
+    function stringToBytes32(string memory source) public pure returns (bytes32 result) {
+        assembly {
+            result := mload(add(source, 32))
+        }
+    }
+
+    function checkSystemValues(SystemValues storage values) internal {
+        // dsr
+        uint expectedDSRRate = rates.rates(values.dsr_rate);
+        // make sure dsr is less than 100% APR
+        // bc -l <<< 'scale=27; e( l(2.00)/(60 * 60 * 24 * 365) )'
+        // 1000000021979553151239153027
+        assertTrue(
+            pot.dsr() >= RAY && pot.dsr() < 1000000021979553151239153027
+        );
+        assertTrue(diffCalc(expectedRate(values.dsr_rate), yearlyYield(expectedDSRRate)) <= TOLERANCE);
+
+        {
+        // Line values in RAD
+        uint normalizedLine = values.vat_Line * RAD;
+        assertEq(vat.Line(), normalizedLine);
+        assertTrue(
+            (vat.Line() >= RAD && vat.Line() < 100 * BILLION * RAD) ||
+            vat.Line() == 0
+        );
+        }
+
+        // Pause delay
+        assertEq(pause.delay(), values.pause_delay);
+
+        // wait
+        assertEq(vow.wait(), values.vow_wait);
+
+        {
+        // dump values in WAD
+        uint normalizedDump = values.vow_dump * WAD;
+        assertEq(vow.dump(), normalizedDump);
+        assertTrue(
+            (vow.dump() >= WAD && vow.dump() < 2 * THOUSAND * WAD) ||
+            vow.dump() == 0
+        );
+        }
+        {
+        // sump values in RAD
+        uint normalizedSump = values.vow_sump * RAD;
+        assertEq(vow.sump(), normalizedSump);
+        assertTrue(
+            (vow.sump() >= RAD && vow.sump() < 500 * THOUSAND * RAD) ||
+            vow.sump() == 0
+        );
+        }
+        {
+        // bump values in RAD
+        uint normalizedBump = values.vow_bump * RAD;
+        assertEq(vow.bump(), normalizedBump);
+        assertTrue(
+            (vow.bump() >= RAD && vow.bump() < HUNDRED * THOUSAND * RAD) ||
+            vow.bump() == 0
+        );
+        }
+        {
+        // hump values in RAD
+        uint normalizedHump = values.vow_hump * RAD;
+        assertEq(vow.hump(), normalizedHump);
+        assertTrue(
+            (vow.hump() >= RAD && vow.hump() < HUNDRED * MILLION * RAD) ||
+            vow.hump() == 0
+        );
+        }
+
+        // box values in RAD
+        {
+            uint normalizedBox = values.cat_box * RAD;
+            assertEq(cat.box(), normalizedBox);
+        }
+
+        // check number of ilks
+        assertEq(reg.count(), values.ilk_count);
+    }
+
+    function checkCollateralValues(bytes32 ilk, SystemValues storage values) internal {
+        (uint duty,)  = jug.ilks(ilk);
+
+        assertEq(duty, rates.rates(values.collaterals[ilk].pct));
+        // make sure duty is less than 1000% APR
+        // bc -l <<< 'scale=27; e( l(10.00)/(60 * 60 * 24 * 365) )'
+        // 1000000073014496989316680335
+        assertTrue(duty >= RAY && duty < 1000000073014496989316680335);  // gt 0 and lt 1000%
+        assertTrue(diffCalc(expectedRate(values.collaterals[ilk].pct), yearlyYield(rates.rates(values.collaterals[ilk].pct))) <= TOLERANCE);
+        assertTrue(values.collaterals[ilk].pct < THOUSAND * THOUSAND);   // check value lt 1000%
+        {
+        (,,, uint line, uint dust) = vat.ilks(ilk);
+        // Convert whole Dai units to expected RAD
+        uint normalizedTestLine = values.collaterals[ilk].line * RAD;
+        assertEq(line, normalizedTestLine);
+        assertTrue((line >= RAD && line < BILLION * RAD) || line == 0);  // eq 0 or gt eq 1 RAD and lt 1B
+        uint normalizedTestDust = values.collaterals[ilk].dust * RAD;
+        assertEq(dust, normalizedTestDust);
+        assertTrue((dust >= RAD && dust < 10 * THOUSAND * RAD) || dust == 0); // eq 0 or gt eq 1 and lt 10k
+        }
+        {
+        (, uint chop, uint dunk) = cat.ilks(ilk);
+        // Convert BP to system expected value
+        uint normalizedTestChop = (values.collaterals[ilk].chop * 10**14) + WAD;
+        assertEq(chop, normalizedTestChop);
+        // make sure chop is less than 100%
+        assertTrue(chop >= WAD && chop < 2 * WAD);   // penalty gt eq 0% and lt 100%
+        // Convert whole Dai units to expected RAD
+        uint normalizedTestDunk = values.collaterals[ilk].dunk * RAD;
+        assertEq(dunk, normalizedTestDunk);
+        // put back in after LIQ-1.2
+        assertTrue(dunk >= RAD && dunk < MILLION * RAD);
+        }
+        {
+        (,uint mat) = spot.ilks(ilk);
+        // Convert BP to system expected value
+        uint normalizedTestMat = (values.collaterals[ilk].mat * 10**23);
+        assertEq(mat, normalizedTestMat);
+        assertTrue(mat >= RAY && mat < 10 * RAY);    // cr eq 100% and lt 1000%
+        }
+        {
+        (address flipper,,) = cat.ilks(ilk);
+        FlipAbstract flip = FlipAbstract(flipper);
+        // Convert BP to system expected value
+        uint normalizedTestBeg = (values.collaterals[ilk].beg + 10000)  * 10**14;
+        assertEq(uint(flip.beg()), normalizedTestBeg);
+        assertTrue(flip.beg() >= WAD && flip.beg() < 105 * WAD / 100);  // gt eq 0% and lt 5%
+        assertEq(uint(flip.ttl()), values.collaterals[ilk].ttl);
+        assertTrue(flip.ttl() >= 600 && flip.ttl() < 10 hours);         // gt eq 10 minutes and lt 10 hours
+        assertEq(uint(flip.tau()), values.collaterals[ilk].tau);
+        assertTrue(flip.tau() >= 600 && flip.tau() <= 3 days);          // gt eq 10 minutes and lt eq 3 days
+
+        assertEq(flip.wards(address(cat)), values.collaterals[ilk].liquidations);  // liquidations == 1 => on
+        assertEq(flip.wards(address(makerDeployer05)), 0); // Check deployer denied
+        assertEq(flip.wards(address(pauseProxy)), 1); // Check pause_proxy ward
+        }
+        {
+        GemJoinAbstract join = GemJoinAbstract(reg.join(ilk));
+        assertEq(join.wards(address(makerDeployer05)), 0); // Check deployer denied
+        assertEq(join.wards(address(pauseProxy)), 1); // Check pause_proxy ward
+        }
+    }
+
+    // function testFailWrongDay() public {
+    //     vote();
+    //     scheduleWaitAndCastFailDay();
+    // }
+
+    // function testFailTooEarly() public {
+    //     vote();
+    //     scheduleWaitAndCastFailEarly();
+    // }
+
+    // function testFailTooLate() public {
+    //     vote();
+    //     scheduleWaitAndCastFailLate();
+    // }
+
+    function testSpellIsCast() public {
+        string memory description = new DssSpell().description();
+        assertTrue(bytes(description).length > 0);
+        // DS-Test can't handle strings directly, so cast to a bytes32.
+        assertEq(stringToBytes32(spell.description()),
+                stringToBytes32(description));
+
+        if(address(spell) != address(MAINNET_SPELL)) {
+            assertEq(spell.expiration(), (now + 30 days));
+        } else {
+            assertEq(spell.expiration(), (SPELL_CREATED + 30 days));
+        }
+
+        vote();
+        scheduleWaitAndCast();
+        assertTrue(spell.done());
+
+        checkSystemValues(afterSpell);
+
+        bytes32[] memory ilks = reg.list();
+        for(uint i = 0; i < ilks.length; i++) {
+            checkCollateralValues(ilks[i],  afterSpell);
+        }
+
+        // Verify that B Protocol has been whitelisted on the ETHUSD Medianizer and OSM
+        address B_PROTOCOL_BUD_CONNECTOR = 0x2325aa20DEAa9770a978f1dc7C073589ffC79DC3;
+        assertEq(1, MedianAbstract(0x64DE91F5A373Cd4c28de3600cB34C7C6cE410C85).bud(B_PROTOCOL_BUD_CONNECTOR));
+        assertEq(1,    OsmAbstract(0x81FE72B5A8d1A857d176C3E7d5Bd2679A9B85763).bud(B_PROTOCOL_BUD_CONNECTOR));
+    }
+}

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -16,17 +16,9 @@
 pragma solidity 0.5.12;
 
 import "lib/dss-interfaces/src/dapp/DSPauseAbstract.sol";
-import "lib/dss-interfaces/src/dss/CatAbstract.sol";
-import "lib/dss-interfaces/src/dss/FlipAbstract.sol";
-import "lib/dss-interfaces/src/dss/IlkRegistryAbstract.sol";
-import "lib/dss-interfaces/src/dss/GemJoinAbstract.sol";
-import "lib/dss-interfaces/src/dss/JugAbstract.sol";
 import "lib/dss-interfaces/src/dss/MedianAbstract.sol";
 import "lib/dss-interfaces/src/dss/OsmAbstract.sol";
-import "lib/dss-interfaces/src/dss/OsmMomAbstract.sol";
-import "lib/dss-interfaces/src/dss/SpotAbstract.sol";
-import "lib/dss-interfaces/src/dss/VatAbstract.sol";
-import "lib/dss-interfaces/src/dss/ChainlogAbstract.sol";
+import "lib/dss-interfaces/src/dss/VowAbstract.sol";
 
 contract SpellAction {
     // MAINNET ADDRESSES
@@ -35,22 +27,14 @@ contract SpellAction {
     //  against the current release list at:
     //     https://changelog.makerdao.com/releases/mainnet/1.1.2/contracts.json
 
-    address constant MCD_VAT         = 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B;
-    address constant MCD_CAT         = 0xa5679C04fc3d9d8b0AaB1F0ab83555b301cA70Ea;
-    address constant MCD_JUG         = 0x19c0976f590D67707E62397C87829d896Dc0f1F1;
-    address constant MCD_SPOT        = 0x65C79fcB50Ca1594B025960e539eD7A9a6D434A3;
-    address constant MCD_POT         = 0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7;
-    address constant MCD_END         = 0xaB14d3CE3F733CACB76eC2AbE7d2fcb00c99F3d5;
-    address constant FLIPPER_MOM     = 0xc4bE7F74Ee3743bDEd8E0fA218ee5cf06397f472;
-    address constant OSM_MOM         = 0x76416A4d5190d071bfed309861527431304aA14f;
-    address constant ILK_REGISTRY    = 0x8b4ce5DCbb01e0e1f0521cd8dCfb31B308E52c24;
-    address constant CHAINLOG        = 0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F;
+    address constant MCD_VOW       = 0xA950524441892A31ebddF91d3cEEFa04Bf454466;
+    address constant ETHUSD_MEDIAN = 0x64DE91F5A373Cd4c28de3600cB34C7C6cE410C85;
+    address constant ETHUSD_OSM    = 0x81FE72B5A8d1A857d176C3E7d5Bd2679A9B85763;
 
-    // ETH-B specific addresses
-    address constant ETH            = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
-    address constant MCD_JOIN_ETH_B = 0x08638eF1A205bE6762A8b935F5da9b700Cf7322c;
-    address constant MCD_FLIP_ETH_B = 0xD499d71bE9e9E5D236A07ac562F7B6CeacCa624c;
-    address constant PIP_ETH        = 0x81FE72B5A8d1A857d176C3E7d5Bd2679A9B85763; // OSM
+    // spell-specific addresses
+
+    // B Protocol
+    address constant B_PROTOCOL_BUD_CONNECTOR = 0x2325aa20DEAa9770a978f1dc7C073589ffC79DC3;
 
     // Decimals & precision
     uint256 constant THOUSAND = 10 ** 3;
@@ -67,11 +51,18 @@ contract SpellAction {
     //
     // A table of rates can be found at
     //    https://ipfs.io/ipfs/QmefQMseb3AiTapiAKKexdKHig8wroKuZbmLtPLv4u2YwW
-    uint256 constant         SIX_PCT_RATE = 1000000001847694957439350562;
+
+    // No rate chagnes this week.
 
     function execute() external {
+        // Set the surplus buffer to 4,000,000 DAI
+        VowAbstract(MCD_VOW).file("hump", 4 * MILLION * RAD);
 
+        // Whitelist B Protocol to access the ETHUSD Medianizer
+        MedianAbstract(ETHUSD_MEDIAN).kiss(B_PROTOCOL_BUD_CONNECTOR);
 
+        // Whitelist B Protocol to access the ETHUSD OSM
+        OsmAbstract(ETHUSD_OSM).kiss(B_PROTOCOL_BUD_CONNECTOR);
     }
 }
 
@@ -85,12 +76,11 @@ contract DssSpell {
     uint256         public expiration;
     bool            public done;
 
-
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
-    // Hash: seth keccak -- "$(wget https://raw.githubusercontent.com/makerdao/community/6a97b8f1f145d86b2ea898826cd3232a5abc7c1d/governance/votes/Executive%20vote%20-%20October%2016%2C%202020.md -q -O - 2>/dev/null)"
+    // Hash: seth keccak -- "$(wget https://raw.githubusercontent.com/makerdao/community/master/governance/votes/Executive%20vote%20-%20October%2023%2C%202020.md -q -O - 2>/dev/null)"
     string constant public description =
-        "2020-10-16 MakerDAO Executive Spell | Hash: 0xbaf455a1f3360f0d9f9941f79626e38344c5c58e96c4d2cf03461995fa1fe913";
+        "2020-10-23 MakerDAO Executive Spell | Hash: 0x500dd161a37646be178bb4a33a1bbef78443f5e60aa660d6d3b480791326c964";
 
     constructor() public {
         sig = abi.encodeWithSignature("execute()");
@@ -117,7 +107,7 @@ contract DssSpell {
         pause.plot(action, tag, sig, eta);
     }
 
-    function cast() public officeHours {
+    function cast() public /* officeHours */ {
         require(!done, "spell-already-cast");
         done = true;
         pause.exec(action, tag, sig, eta);

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -25,7 +25,7 @@ contract SpellAction {
     //
     // The contracts in this list should correspond to MCD core contracts, verify
     //  against the current release list at:
-    //     https://changelog.makerdao.com/releases/mainnet/1.1.2/contracts.json
+    //     https://changelog.makerdao.com/releases/mainnet/1.1.3/contracts.json
 
     address constant MCD_VOW       = 0xA950524441892A31ebddF91d3cEEFa04Bf454466;
     address constant ETHUSD_MEDIAN = 0x64DE91F5A373Cd4c28de3600cB34C7C6cE410C85;
@@ -78,7 +78,7 @@ contract DssSpell {
 
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
-    // Hash: seth keccak -- "$(wget https://raw.githubusercontent.com/makerdao/community/master/governance/votes/Executive%20vote%20-%20October%2023%2C%202020.md -q -O - 2>/dev/null)"
+    // Hash: seth keccak -- "$(wget https://raw.githubusercontent.com/makerdao/community/10f4fb51d9d6b292d7ffd3f852cbbc97bd920e84/governance/votes/Executive%20vote%20-%20October%2023%2C%202020.md -q -O - 2>/dev/null)"
     string constant public description =
         "2020-10-23 MakerDAO Executive Spell | Hash: 0x500dd161a37646be178bb4a33a1bbef78443f5e60aa660d6d3b480791326c964";
 

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -21,9 +21,9 @@ interface MedianizerV1Abstract {
 
 contract DssSpellTest is DSTest, DSMath {
     // populate with mainnet spell if needed
-    address constant MAINNET_SPELL = address(0);
+    address constant MAINNET_SPELL = address(0xb04A29de213411DDb7196eD1327b3B6144893E59);
     // this needs to be updated
-    uint256 constant SPELL_CREATED = 1602860406;
+    uint256 constant SPELL_CREATED = 1603464858;
 
     struct CollateralValues {
         uint256 line;

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -153,7 +153,7 @@ contract DssSpellTest is DSTest, DSMath {
             vow_dump:     250,             // In whole Dai units
             vow_sump:     50000,           // In whole Dai units
             vow_bump:     10000,           // In whole Dai units
-            vow_hump:     2 * MILLION,     // In whole Dai units
+            vow_hump:     4 * MILLION,     // In whole Dai units
             cat_box:      15 * MILLION,    // In whole Dai units
             ilk_count:    15               // Num expected in system
         });
@@ -605,5 +605,10 @@ contract DssSpellTest is DSTest, DSMath {
         for(uint i = 0; i < ilks.length; i++) {
             checkCollateralValues(ilks[i],  afterSpell);
         }
+
+        // Verify that B Protocol has been whitelisted on the ETHUSD Medianizer and OSM
+        address B_PROTOCOL_BUD_CONNECTOR = 0x2325aa20DEAa9770a978f1dc7C073589ffC79DC3;
+        assertEq(1, MedianAbstract(0x64DE91F5A373Cd4c28de3600cB34C7C6cE410C85).bud(B_PROTOCOL_BUD_CONNECTOR));
+        assertEq(1,    OsmAbstract(0x81FE72B5A8d1A857d176C3E7d5Bd2679A9B85763).bud(B_PROTOCOL_BUD_CONNECTOR));
     }
 }


### PR DESCRIPTION
# Description
https://app.clubhouse.io/maker/story/6623/2020-10-23-executive

Governance copy:
https://github.com/makerdao/community/blob/master/governance/votes/Executive%20vote%20-%20October%2023%2C%202020.md

Increases the surplus buffer to 4 million DAI and whitelists B Protocol to read from the ETHUSD `Median` and `Osm`.


# Contribution Checklist

- [x] First commit title starts with 'SC-**TICKET_NUMBER**:'
- [x] Link to clubhouse ticket
- [x] Code approved
- [x] Tests approved
- [x] CI Tests pass

# Checklist

- [x] Every contract variable/method declared as public/external private/internal
- [x] Consider if this PR needs the `officeHours` modifier
- [x] Verify expiration (`4 days + 2 hours` monthly and `30 days` for the rest)
- [x] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [x] Validate all addresses used are in changelog or known
- [x] Deploy spell `SOLC_FLAGS="--optimize --optimize-runs=1" dapp --use solc:0.5.12 build && dapp create DssSpell --gas=XXX --gas-price="$(seth --to-wei YYY "gwei")"`
- [x] Verify `mainnet` contract on etherscan
- [x] Change test to use mainnet spell address and deploy timestamp
- [x] Keep `DssSpell.sol` and `DssSpell.t.sol` the same, but make a copy in `archive`
- [ ] `squash and merge` this PR
