### PR TITLE
feat: Change address to optional param in compare-bytecode.sh

### DIFF
--- a/compare-bytecode.sh
+++ b/compare-bytecode.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 # Purpose:
 #  To compare the runtime bytecode of the current spell (src/DssSpell.sol) as
 #  output by the compiler against the onchain bytecode of a provided contract
@@ -23,7 +22,8 @@
 make all &> /dev/null
 COMPILED_BYTECODE=0x`jq '.contracts|.["src/DssSpell.sol:DssSpell"]|.["bin-runtime"]' ./out/dapp.sol.json | sed 's/"//g'`
 CB=${COMPILED_BYTECODE::-104}  # Trim swarm hash
-ONCHAIN_BYTECODE=`curl -s --data '{"method": "eth_getCode", "params":["'${1}'", "latest"], "id":1, "jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST ${ETH_RPC_URL} | jq '.result' | sed 's/"//g'`
+DEPLOYED_ADDRESS=`cat src/DssSpell.t.sol | grep "address constant MAINNET_SPELL" | sed -e 's#.*address(\(\)#\1#' | sed 's/);.*//'`
+ONCHAIN_BYTECODE=`curl -s --data '{"method": "eth_getCode", "params":["'${1-$DEPLOYED_ADDRESS}'", "latest"], "id":1, "jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST ${ETH_RPC_URL} | jq '.result' | sed 's/"//g'`
 OB=${ONCHAIN_BYTECODE::-104}  # Trim swarm hash
 if [ "$CB" = "$OB" ] ; then
     echo -e "\e[32mSUCCESS! \e[39mBytecodes match."

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -153,7 +153,7 @@ contract DssSpellTest is DSTest, DSMath {
             vow_dump:     250,             // In whole Dai units
             vow_sump:     50000,           // In whole Dai units
             vow_bump:     10000,           // In whole Dai units
-            vow_hump:     2 * MILLION,     // In whole Dai units
+            vow_hump:     4 * MILLION,     // In whole Dai units
             cat_box:      15 * MILLION,    // In whole Dai units
             ilk_count:    15               // Num expected in system
         });


### PR DESCRIPTION
Change address to optional param in bytecode script, if not provided, pulls from test file.
```
➜  spells-mainnet git:(add-deployed-address-check) ./compare-bytecode.sh 0xBc59B45F54f88EfD5f8f5cf0FbcBf5970A9255cc
SUCCESS! Bytecodes match.
➜  spells-mainnet git:(add-deployed-address-check) ✗ ./compare-bytecode.sh 0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F
FAILURE. Bytecodes do NOT match.
➜  spells-mainnet git:(add-deployed-address-check) ✗ ./compare-bytecode.sh
SUCCESS! Bytecodes match.
```


