### PR TITLE
Show bytecode snippet

### DIFF
--- a/compare-bytecode.sh
+++ b/compare-bytecode.sh
@@ -25,6 +25,8 @@ CB=${COMPILED_BYTECODE::${#COMPILED_BYTECODE}-104}  # Trim swarm hash
 DEPLOYED_ADDRESS=`cat src/DssSpell.t.sol | grep "address constant MAINNET_SPELL" | sed -e 's#.*address(\(\)#\1#' | sed 's/);.*//'`
 ONCHAIN_BYTECODE=`curl -s --data '{"method": "eth_getCode", "params":["'${1-$DEPLOYED_ADDRESS}'", "latest"], "id":1, "jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST ${ETH_RPC_URL} | jq '.result' | sed 's/"//g'`
 OB=${ONCHAIN_BYTECODE::${#ONCHAIN_BYTECODE}-104}  # Trim swarm hash
+echo "Compiled Bytecode: ${CB:0:40}..."
+echo "On-Chain Bytecode: ${OB:0:40}..."
 if [ "$CB" = "$OB" ] ; then
     echo -e "\e[32mSUCCESS! \e[39mBytecodes match."
 else


### PR DESCRIPTION
# Description

Adds an output to the bytecode checker to verify that compared variables are not null.

```
bmcmichael@bmcx1c:~/makerdao/dss-launch$ ./compare-bytecode.sh 
Compiled Bytecode: 0x608060405234801561001057600080fd5b5060...
On-Chain Bytecode: 0x608060405234801561001057600080fd5b5060...
SUCCESS! Bytecodes match.
```

If variables are null they will match, this just echoes a portion of the variables that are being compared as a sanity check.