### PR TITLE
Test wasn't actually checking the POT dsr value + adding a missing er…

### DIFF
--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -1513,11 +1513,15 @@ contract DssSpellTest is DSTest, DSMath {
         // make sure dsr is less than 100% APR
         // bc -l <<< 'scale=27; e( l(2.00)/(60 * 60 * 24 * 365) )'
         // 1000000021979553151239153027
+        assertEq(pot.dsr(), expectedDSRRate, "TestError/pot-dsr-expected-value");
         assertTrue(
             pot.dsr() >= RAY && pot.dsr() < 1000000021979553151239153027,
             "TestError/pot-dsr-range"
         );
-        assertTrue(diffCalc(expectedRate(values.pot_dsr), yearlyYield(expectedDSRRate)) <= TOLERANCE);
+        assertTrue(
+            diffCalc(expectedRate(values.pot_dsr), yearlyYield(expectedDSRRate)) <= TOLERANCE,
+            "TestError/pot-dsr-rates-table"
+        );
 
         {
         // Line values in RAD


### PR DESCRIPTION
…ror message

# Description

# Contribution Checklist

- [ ] PR title starts with `(PE-<TICKET_NUMBER>)`
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier
- [ ] Verify expiration (`4 days` monthly and `30 days` for the rest)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell `ETH_GAS="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Verify `mainnet` contract on etherscan
- [ ] Change test to use mainnet spell address and deploy timestamp
- [ ] Keep `DssSpell.sol` and `DssSpell.t.sol` the same, but make a copy in `archive`
- [ ] `squash and merge` this PR
