### PR TITLE
Source dapprc

### DIFF
--- a/test-dssspell.sh
+++ b/test-dssspell.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-[[ "$ETH_RPC_URL" ]] || source ~/.dapprc
+[[ "$ETH_RPC_URL" ]] || source ~/.sethrc
 
 [[ "$ETH_RPC_URL" && "$(seth chain)" == "ethlive"  ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1;  }
 

--- a/test-dssspell.sh
+++ b/test-dssspell.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-[[ "$ETH_RPC_URL" ]] || source ~/.sethrc
+source ~/.sethrc
 
 [[ "$ETH_RPC_URL" && "$(seth chain)" == "ethlive"  ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1;  }
 

--- a/test-dssspell.sh
+++ b/test-dssspell.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-source ~/.sethrc
-
-[[ "$ETH_RPC_URL" && "$(seth chain)" == "ethlive"  ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1;  }
+[[ "$ETH_RPC_URL" && "$(seth chain --rpc-url=$ETH_RPC_URL)" == "ethlive"  ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1;  }
 
 export DAPP_BUILD_OPTIMIZE=1
 export DAPP_BUILD_OPTIMIZE_RUNS=1

--- a/test-dssspell.sh
+++ b/test-dssspell.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-source ~/.dapprc
+[[ "$ETH_RPC_URL" ]] || source ~/.dapprc
 
 [[ "$ETH_RPC_URL" && "$(seth chain)" == "ethlive"  ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1;  }
 

--- a/test-dssspell.sh
+++ b/test-dssspell.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-[[ "$ETH_RPC_URL" && "$(seth chain --rpc-url=$ETH_RPC_URL)" == "ethlive"  ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1;  }
+[[ "$(seth chain --rpc-url=$ETH_RPC_URL)" == "ethlive"  ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1;  }
 
 export DAPP_BUILD_OPTIMIZE=1
 export DAPP_BUILD_OPTIMIZE_RUNS=1

--- a/test-dssspell.sh
+++ b/test-dssspell.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+source ~/.dapprc
+
 [[ "$ETH_RPC_URL" && "$(seth chain)" == "ethlive"  ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1;  }
 
 export DAPP_BUILD_OPTIMIZE=1


### PR DESCRIPTION
# Description

`seth chain` appears to always source from sethrc if it exports `ETH_RPC_URL` so we should use the `--rpc-url` [flag](https://github.com/dapphub/dapptools/tree/master/src/seth#connecting-to-the-blockchain) for `seth chain` This prevents hidden defaults. 

Test case to show the issue:
1. define `ETH_RPC_URL` in your `.sethrpc` file.
2. in your terminal `export ETH_RPC_URL=a`  
3. run `make test`
4. You should not get past the check for `ETH_RPC_URL && $(seth chain) == "ethlive"` but on the main branch you would and the tests will fail because `a` is not a valid URL.

My concern is that if we export an ETH_RPC_URL but also have one set in `sethrc` then `seth chain` would us the `sethrc` one.  This change forces it to use the exported one which is the same thing we are doing for `dapp` when we actually run the tests.

# Contribution Checklist

- [ ] PR title starts with `(PE-<TICKET_NUMBER>)`
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier
- [ ] Verify expiration (`4 days` monthly and `30 days` for the rest)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell `ETH_GAS="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Verify `mainnet` contract on etherscan
- [ ] Change test to use mainnet spell address and deploy timestamp
- [ ] Keep `DssSpell.sol` and `DssSpell.t.sol` the same, but make a copy in `archive`
- [ ] `squash and merge` this PR
