### PR TITLE
generalize give tokens for Gems and Gov

### DIFF
--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -254,7 +254,7 @@ contract DssSpellTestBase is Config, DSTest, DSMath {
 
     function vote(address spell_) internal {
         if (chief.hat() != spell_) {
-            giveTokens(gov, 999999999999 ether);
+            giveTokens(address(gov), 999999999999 ether);
             gov.approve(address(chief), uint256(-1));
             chief.lock(999999999999 ether);
 
@@ -612,9 +612,9 @@ contract DssSpellTestBase is Config, DSTest, DSMath {
         return price;
     }
 
-    function giveTokens(DSTokenAbstract token, uint256 amount) internal {
+    function giveTokens(address token, uint256 amount) internal {
         // Edge case - balance is already set for some reason
-        if (token.balanceOf(address(this)) == amount) return;
+        if (GemAbstract(token).balanceOf(address(this)) == amount) return;
 
         // Scan the storage for the balance storage slot
         for (uint256 i = 0; i < 200; i++) {
@@ -630,7 +630,7 @@ contract DssSpellTestBase is Config, DSTest, DSMath {
                     keccak256(abi.encode(address(this), uint256(i))),
                     bytes32(amount)
                 );
-                if (token.balanceOf(address(this)) == amount) {
+                if (GemAbstract(token).balanceOf(address(this)) == amount) {
                     // Found it
                     return;
                 } else {
@@ -655,7 +655,7 @@ contract DssSpellTestBase is Config, DSTest, DSMath {
                     keccak256(abi.encode(uint256(i), address(this))),
                     bytes32(amount)
                 );
-                if (token.balanceOf(address(this)) == amount) {
+                if (GemAbstract(token).balanceOf(address(this)) == amount) {
                     // Found it
                     return;
                 } else {
@@ -742,7 +742,7 @@ contract DssSpellTestBase is Config, DSTest, DSMath {
         dust /= RAY;
         uint256 amount = 2 * dust * 10**token.decimals() / (_isOSM ? getOSMPrice(pip) : uint256(DSValueAbstract(pip).read()));
         uint256 amount18 = token.decimals() == 18 ? amount : amount * 10**(18 - token.decimals());
-        giveTokens(token, amount);
+        giveTokens(address(token), amount);
 
         assertEq(token.balanceOf(address(this)), amount);
         assertEq(vat.gem(_ilk, address(this)), 0);
@@ -837,7 +837,7 @@ contract DssSpellTestBase is Config, DSTest, DSMath {
         (,,,, uint256 dust) = vat.ilks(_ilk);
         dust /= RAY;
         uint256 amount = 2 * dust * WAD / getUNIV2LPPrice(address(pip));
-        giveTokens(token, amount);
+        giveTokens(address(token), amount);
 
         assertEq(token.balanceOf(address(this)), amount);
         assertEq(vat.gem(_ilk, address(this)), 0);
@@ -912,7 +912,7 @@ contract DssSpellTestBase is Config, DSTest, DSMath {
         assertEq(psm.tout(), tout);
 
         uint256 amount = 1000 * (10 ** token.decimals());
-        giveTokens(token, amount);
+        giveTokens(address(token), amount);
 
         // Approvals
         token.approve(address(join), amount);
@@ -1035,7 +1035,7 @@ contract DssSpellTestBase is Config, DSTest, DSMath {
 
         (,,,, uint256 dust) = vat.ilks(_ilk);
         uint256 amount = 2 * dust / (getUNIV2LPPrice(address(pip)) * 1e9);
-        giveTokens(DSTokenAbstract(join.gem()), amount);
+        giveTokens(address(join.gem()), amount);
 
         assertEq(DSTokenAbstract(join.gem()).balanceOf(address(this)), amount);
         assertEq(vat.gem(_ilk, cropper.getOrCreateProxy(address(this))), 0);
@@ -1084,7 +1084,7 @@ contract DssSpellTestBase is Config, DSTest, DSMath {
             hevm.warp(block.timestamp + 1);
             jug.drip(_ilk);
             assertEq(clip.kicks(), 0);
-            
+
             // Kick off the liquidation
             dog.bark(_ilk, cropper.getOrCreateProxy(address(this)), address(this));
             assertEq(clip.kicks(), 1);

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -44,7 +44,7 @@ contract DssSpellTest is DssSpellTestBase {
         address MCD_JOIN_TUSD_A = addr.addr("MCD_JOIN_TUSD_A");
 
         uint256 amount = 86 * THOUSAND * WAD;
-        giveTokens(DSTokenAbstract(TUSD), amount);
+        giveTokens(TUSD, amount);
         DSTokenAbstract(TUSD).approve(MCD_JOIN_TUSD_A, amount);
         GemJoin6Like(MCD_JOIN_TUSD_A).join(address(this), amount);
         assertEq(vat.gem("TUSD-A", address(this)), amount);


### PR DESCRIPTION
So that we can use `GemAbstract` for gems and `DSTokenAbstract` for `gov`, we need to generalize the input for `giveTokens`

