### PR TITLE
Pe 1184 : add relay to L2 

### DIFF
--- a/scripts/get-arb-relay-cost.sh
+++ b/scripts/get-arb-relay-cost.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -e
+
+[[ "$(cast chain --rpc-url="$ETH_RPC_URL")" == "ethlive" ]] || { echo "Please set a Goerli ETH_RPC_URL"; exit 1; }
+
+ARBITRUM_GOERLI_RPC_URL='https://arb1.arbitrum.io/rpc'
+
+L2_SPELL='0x852CCBB823D73b3e35f68AD6b14e29B02360FD3d'
+CHANGELOG='0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F'
+NODE_INTERFACE='0x00000000000000000000000000000000000000C8'
+
+L1_GOV_RELAY=$(
+    cast call $CHANGELOG "getAddress(bytes32)(address)" \
+    $(cast --format-bytes32-string "ARBITRUM_GOV_RELAY")
+)
+L2_GOV_RELAY=$(cast call $L1_GOV_RELAY "l2GovernanceRelay()(address)")
+INBOX=$(cast call $L1_GOV_RELAY "inbox()(address)")
+
+BASE_FEE_SAFETY_FACTOR=20 # Factor by which L1 block.basefee could grow between now and the spell cast time
+
+ARB_GAS_PRICE_BID=$(cast gas-price --rpc-url $ARBITRUM_GOERLI_RPC_URL)
+RELAY_CALLDATA=$(
+    cast calldata "relay(address,bytes)" $L2_SPELL $(cast calldata "execute()")
+)
+ARB_MAX_GAS=$(
+    cast estimate --rpc-url $ARBITRUM_GOERLI_RPC_URL \
+    $NODE_INTERFACE \
+    "estimateRetryableTicket(address,uint256,address,uint256,address,address,bytes)" \
+    $L1_GOV_RELAY \
+    1000000000000000000 \
+    $L2_GOV_RELAY \
+    0 \
+    $L2_GOV_RELAY \
+    $L2_GOV_RELAY \
+    $RELAY_CALLDATA
+)
+RELAY_CALLDATA_LEN=$(( $(echo -n $RELAY_CALLDATA | wc -c) / 2 - 1 ))
+SUBMISSION_FEE=$(
+    cast call $INBOX \
+    "calculateRetryableSubmissionFee(uint256,uint256)(uint256)" \
+    $RELAY_CALLDATA_LEN \
+    0
+)
+ARB_MAX_SUBMISSION_COST=$(($SUBMISSION_FEE * $BASE_FEE_SAFETY_FACTOR))
+ARB_L1_CALL_VALUE=$(($ARB_MAX_GAS * $ARB_GAS_PRICE_BID + $ARB_MAX_SUBMISSION_COST))
+
+echo "ARB_MAX_GAS             = $ARB_MAX_GAS"
+echo "ARB_GAS_PRICE_BID       = $ARB_GAS_PRICE_BID"
+echo "ARB_MAX_SUBMISSION_COST = $ARB_MAX_SUBMISSION_COST"
+echo "ARB_L1_CALL_VALUE       = $ARB_L1_CALL_VALUE"

--- a/scripts/get-opt-relay-cost.sh
+++ b/scripts/get-opt-relay-cost.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+trap 'kill $(jobs -p) 2>/dev/null' EXIT
+
+[[ "$(cast chain --rpc-url="$ETH_RPC_URL")" == "ethlive" ]] || { echo "Please set a Mainnet ETH_RPC_URL"; exit 1; }
+
+OPTIMISM_GOERLI_RPC_URL='https://mainnet.optimism.io'
+
+L2_SPELL='0x9495632F53Cc16324d2FcFCdD4EB59fb88dDab12'
+CHANGELOG='0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F'
+X_DOMAIN_MSG_SENDER_SLOT=4 # Note: this become 204 after the Bedrock update!
+
+L1_GOV_RELAY=$(
+    cast call $CHANGELOG "getAddress(bytes32)(address)" \
+    $(cast --format-bytes32-string "OPTIMISM_GOV_RELAY")
+)
+L2_GOV_RELAY=$(cast call $L1_GOV_RELAY "l2GovernanceRelay()(address)")
+L2_MESSENGER=$(cast call --rpc-url=$OPTIMISM_GOERLI_RPC_URL $L2_GOV_RELAY "messenger()(address)")
+
+PORT=8555
+LOCALHOST=http://127.0.0.1:$PORT
+
+anvil -f $OPTIMISM_GOERLI_RPC_URL -p $PORT > /dev/null 2>&1 &
+sleep 20
+
+cast rpc --rpc-url=$LOCALHOST anvil_setStorageAt $L2_MESSENGER \
+    $(printf 0x"%064X\n" $X_DOMAIN_MSG_SENDER_SLOT) \
+    $(printf 0x"%064s\n" ${L1_GOV_RELAY:2} | tr ' ' 0) > /dev/null
+OPT_GAS=$(
+    cast estimate --rpc-url=$LOCALHOST --from $L2_MESSENGER \
+    $L2_GOV_RELAY \
+    "relay(address,bytes)" \
+    $L2_SPELL \
+    $(cast calldata "execute()")
+)
+
+echo "OPT_GAS = $OPT_GAS"

--- a/scripts/get-opt-relay-cost.sh
+++ b/scripts/get-opt-relay-cost.sh
@@ -8,7 +8,7 @@ OPTIMISM_GOERLI_RPC_URL='https://mainnet.optimism.io'
 
 L2_SPELL='0x9495632F53Cc16324d2FcFCdD4EB59fb88dDab12'
 CHANGELOG='0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F'
-X_DOMAIN_MSG_SENDER_SLOT=4 # Note: this become 204 after the Bedrock update!
+X_DOMAIN_MSG_SENDER_SLOT=4 # Note: this becomes 204 after the Bedrock update!
 
 L1_GOV_RELAY=$(
     cast call $CHANGELOG "getAddress(bytes32)(address)" \

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -19,6 +19,29 @@ pragma solidity 0.8.16;
 import "dss-exec-lib/DssExec.sol";
 import "dss-exec-lib/DssAction.sol";
 
+interface OptimismGovRelayLike {
+    function relay(address target, bytes calldata targetData, uint32 l2gas) external;
+}
+
+interface ArbitrumGovRelayLike {
+    function relay(
+        address target,
+        bytes calldata targetData,
+        uint256 l1CallValue,
+        uint256 maxGas,
+        uint256 gasPriceBid,
+        uint256 maxSubmissionCost
+    ) external payable;
+}
+
+interface StarknetGovRelayLike {
+    function relay(uint256 spell) external payable;
+}
+
+interface StarknetEscrowLike {
+    function approve(address token, address spender, uint256 value) external;
+}
+
 contract DssSpellAction is DssAction {
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
@@ -46,13 +69,78 @@ contract DssSpellAction is DssAction {
     address internal constant COM_WALLET  = 0x1eE3ECa7aEF17D1e74eD7C447CcBA61aC76aDbA9;
     address internal constant SF01_WALLET = 0x4Af6f22d454581bF31B2473Ebe25F5C6F55E028D;
 
+    address immutable internal OPTIMISM_GOV_RELAY = DssExecLib.getChangelogAddress("OPTIMISM_GOV_RELAY");
+    address immutable internal ARBITRUM_GOV_RELAY = DssExecLib.getChangelogAddress("ARBITRUM_GOV_RELAY");
+    address immutable internal STARKNET_GOV_RELAY = DssExecLib.getChangelogAddress("STARKNET_GOV_RELAY");
+
+    address immutable internal DAI = DssExecLib.getChangelogAddress("MCD_DAI");
+    address immutable internal STARKNET_ESCROW = DssExecLib.getChangelogAddress("STARKNET_ESCROW");
+    address immutable internal STARKNET_DAI_BRIDGE_LEGACY = DssExecLib.getChangelogAddress("STARKNET_DAI_BRIDGE_LEGACY");
+
+    address constant internal OPTIMISM_L2_SPELL = 0x9495632F53Cc16324d2FcFCdD4EB59fb88dDab12;
+    address constant internal ARBITRUM_L2_SPELL = 0x852CCBB823D73b3e35f68AD6b14e29B02360FD3d;
+    // uint256 constant internal STARKNET_L2_SPELL = ;
+
+    // run ./scripts/get-opt-relay-cost.sh to help determine Optimism relay param
+    uint32 public constant OPT_MAX_GAS = 100_000; // = 44582 gas (estimated L2 execution cost) + margin
+
+    // run ./scripts/get-arb-relay-cost.sh to help determine Arbitrum relay params
+    uint256 public constant ARB_MAX_GAS = 100_000; // = 38_920 gas (estimated L1 calldata + L2 execution cost) + margin (to account for surge in L1 basefee)
+    uint256 public constant ARB_GAS_PRICE_BID = 1_000_000_000; // = 0.1 gwei + 0.9 gwei margin
+    uint256 public constant ARB_MAX_SUBMISSION_COST = 1e15; // = ~0.7 * 10^15 (@ ~15 gwei L1 basefee) rounded up to 1*10^15
+    uint256 public constant ARB_L1_CALL_VALUE = ARB_MAX_SUBMISSION_COST + ARB_MAX_GAS * ARB_GAS_PRICE_BID;
+
+    // see: https://github.com/makerdao/starknet-spells-goerli/tree/teleport-spell#estimate-l1-l2-fee
+    // uint256 public constant STA_GAS_USAGE_ESTIMATION = 28460;
+
+    // 500gwei, ~upper bound of monthly avg gas price in `21-`22,
+    // ~100x max monthly median gas price in `21-`22
+    // https://explorer.bitquery.io/ethereum/gas?from=2021-01-01&till=2023-01-31
+    // uint256 public constant STA_GAS_PRICE = 500000000000;
+    // uint256 public constant STA_L1_CALL_VALUE = STA_GAS_USAGE_ESTIMATION * STA_GAS_PRICE;
+
     function actions() public override {
+        // ------------------ Pause Optimism Goerli L2DaiTeleportGateway -----------------
+        // Forum: https://forum.makerdao.com/t/community-notice-pecu-to-redeploy-teleport-l2-gateways/19550
+        // L2 Spell to execute via OPTIMISM_GOV_RELAY:
+        // https://optimistic.etherscan.io/address/0x9495632f53cc16324d2fcfcdd4eb59fb88ddab12#code
+        OptimismGovRelayLike(OPTIMISM_GOV_RELAY).relay(
+            OPTIMISM_L2_SPELL,
+            abi.encodeWithSignature("execute()"),
+            OPT_MAX_GAS
+        );
+
+        // ------------------ Pause Arbitrum Goerli L2DaiTeleportGateway -----------------
+        // Forum: https://forum.makerdao.com/t/community-notice-pecu-to-redeploy-teleport-l2-gateways/19550
+        // L2 Spell to execute via ARBITRUM_GOV_RELAY:
+        // https://arbiscan.io/address/0x852ccbb823d73b3e35f68ad6b14e29b02360fd3d#code
+        // Note: ARBITRUM_GOV_RELAY must have been pre-funded with at least ARB_L1_CALL_VALUE worth of Ether
+        ArbitrumGovRelayLike(ARBITRUM_GOV_RELAY).relay(
+            ARBITRUM_L2_SPELL,
+            abi.encodeWithSignature("execute()"),
+            ARB_L1_CALL_VALUE,
+            ARB_MAX_GAS,
+            ARB_GAS_PRICE_BID,
+            ARB_MAX_SUBMISSION_COST
+        );
+
+        // ------------------ Pause Starknet Goerli L2DaiTeleportGateway -----------------
+        // Forum: https://forum.makerdao.com/t/community-notice-pecu-to-redeploy-teleport-l2-gateways/19550
+        // L2 Spell to execute via STARKNET_GOV_RELAY:
+        // src: https://github.com/makerdao/starknet-spells-goerli/blob/b7ca995cf1d266aa2382d85e35a86b4fae52aa15/src/spell.cairo
+        // contract: https://testnet.starkscan.co/class/0x00a052591661d7e249b46a1084c63b14dae6aa8b1a56ab3f7df8c8add1c374b1#overview
+        // StarknetGovRelayLike(STARKNET_GOV_RELAY).relay{value: STA_L1_CALL_VALUE}(STARKNET_L2_SPELL);
+
+        // disallow legacy bridge on escrow
+        // Forum: https://forum.makerdao.com/t/starknet-changes-for-executive-spell-on-the-week-of-2023-01-30/19607
+        StarknetEscrowLike(STARKNET_ESCROW).approve(DAI, STARKNET_DAI_BRIDGE_LEGACY, 0);
+
         // Tech-Ops DAI Transfer
         // https://vote.makerdao.com/polling/QmUMnuGb
         DssExecLib.sendPaymentFromSurplusBuffer(TECH_WALLET, 138_894);
 
         // GovComms offboarding
-        // https://vote.makerdao.com/polling/QmV9iktK 
+        // https://vote.makerdao.com/polling/QmV9iktK
         // https://forum.makerdao.com/t/mip39c3-sp7-core-unit-offboarding-com-001/19068/65
         DssExecLib.sendPaymentFromSurplusBuffer(COM_WALLET, 131_200);
         DssExecLib.sendPaymentFromSurplusBuffer(0x50D2f29206a76aE8a9C2339922fcBCC4DfbdD7ea, 1_336);

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -127,8 +127,8 @@ contract DssSpellAction is DssAction {
         // ------------------ Pause Starknet Goerli L2DaiTeleportGateway -----------------
         // Forum: https://forum.makerdao.com/t/community-notice-pecu-to-redeploy-teleport-l2-gateways/19550
         // L2 Spell to execute via STARKNET_GOV_RELAY:
-        // src: https://github.com/makerdao/starknet-spells-goerli/blob/b7ca995cf1d266aa2382d85e35a86b4fae52aa15/src/spell.cairo
-        // contract: https://testnet.starkscan.co/class/0x00a052591661d7e249b46a1084c63b14dae6aa8b1a56ab3f7df8c8add1c374b1#overview
+        // src: https://github.com/makerdao/starknet-spells-mainnet/blob/55401e8121f93d09f57f61c4e77dc0b6c73fb4f8/src/spell.cairo
+        // contract: https://{TBD}
         // StarknetGovRelayLike(STARKNET_GOV_RELAY).relay{value: STA_L1_CALL_VALUE}(STARKNET_L2_SPELL);
 
         // disallow legacy bridge on escrow

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -563,7 +563,7 @@ contract DssSpellTest is DssSpellTestBase {
     }
 
     function _setupRootDomain() internal {
-        vm.makePersistent(address(spell), address(spell.action()));
+        vm.makePersistent(address(spell), address(spell.action()), address(addr));
 
         string memory root = string.concat(vm.projectRoot(), "/lib/dss-test");
         config = ScriptTools.readInput(root, "integration");
@@ -571,10 +571,7 @@ contract DssSpellTest is DssSpellTestBase {
         rootDomain = new RootDomain(config, getRelativeChain("mainnet"));
     }
 
-    function testL2OptimismSpell() private {
-        // Ensure the Pause Proxy has some ETH for L2 Spells
-        assertGt(pauseProxy.balance, 0);
-
+    function testL2OptimismSpell() public {
         address l2TeleportGateway = BridgeLike(
             chainLog.getAddress("OPTIMISM_TELEPORT_BRIDGE")
         ).l2TeleportGateway();
@@ -610,10 +607,7 @@ contract DssSpellTest is DssSpellTestBase {
         assertEq(optimismGateway.validDomains(optDstDomain), 0, "l2-optimism-invalid-dst-domain");
     }
 
-    function testL2ArbitrumSpell() private {
-        // Ensure the Pause Proxy has some ETH for L2 Spells
-        assertGt(pauseProxy.balance, 0);
-
+    function testL2ArbitrumSpell() public {
         address l2TeleportGateway = BridgeLike(
             chainLog.getAddress("ARBITRUM_TELEPORT_BRIDGE")
         ).l2TeleportGateway();

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -585,7 +585,7 @@ contract DssSpellTest is DssSpellTestBase {
         optimismDomain.selectFork();
 
         // Check that the L2 Optimism Spell is there and configured
-        L2Spell optimismSpell = L2Spell(address(0) /* <TODO> */);
+        L2Spell optimismSpell = L2Spell(0x9495632F53Cc16324d2FcFCdD4EB59fb88dDab12);
 
         L2Gateway optimismGateway = L2Gateway(optimismSpell.gateway());
         assertEq(address(optimismGateway), l2TeleportGateway, "l2-optimism-wrong-gateway");
@@ -619,12 +619,12 @@ contract DssSpellTest is DssSpellTestBase {
         ).l2TeleportGateway();
 
         _setupRootDomain();
-        
+
         arbitrumDomain = new ArbitrumDomain(config, getRelativeChain("arbitrum_one"), rootDomain);
         arbitrumDomain.selectFork();
 
         // Check that the L2 Arbitrum Spell is there and configured
-        L2Spell arbitrumSpell = L2Spell(address(0) /* <TODO> */);
+        L2Spell arbitrumSpell = L2Spell(0x852CCBB823D73b3e35f68AD6b14e29B02360FD3d);
 
         L2Gateway arbitrumGateway = L2Gateway(arbitrumSpell.gateway());
         assertEq(address(arbitrumGateway), l2TeleportGateway, "l2-arbitrum-wrong-gateway");

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -608,6 +608,9 @@ contract DssSpellTest is DssSpellTestBase {
     }
 
     function testL2ArbitrumSpell() public {
+        // Ensure the Arbitrum Gov Relay has some ETH to pay for the Arbitrum spell
+        assertGt(chainLog.getAddress("ARBITRUM_GOV_RELAY").balance, 0);
+
         address l2TeleportGateway = BridgeLike(
             chainLog.getAddress("ARBITRUM_TELEPORT_BRIDGE")
         ).l2TeleportGateway();

--- a/src/test/starknet.t.sol
+++ b/src/test/starknet.t.sol
@@ -90,7 +90,7 @@ contract StarknetTests is DssSpellTestBase, ConfigStarknet {
 
     function testStarknet() public {
         if (l2Spell != 0) {
-            // Ensure the Pause Proxy has some ETH for Starknet Spell
+            // Ensure the Pause Proxy has some ETH for the Starknet Spell
             assertGt(pauseProxy.balance, 0);
         }
 


### PR DESCRIPTION
# Description

# Contribution Checklist

- [ ] PR title starts with `(PE-<TICKET_NUMBER>)`
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier override
- [ ] Verify expiration (`30 days` unless otherwise specified)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell `ETH_GAS_LIMIT="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Verify `mainnet` contract on etherscan
- [ ] Change test to use mainnet spell address and deploy timestamp
- [ ] Run `make archive-spell` or `make date="YYYY-MM-DD" archive-spell` to make an archive directory and copy `DssSpell.sol`, `DssSpell.t.sol`, `DssSpell.t.base.sol`, and `DssSpellCollateralOnboarding.sol`
- [ ] `squash and merge` this PR
