### PR TITLE
Fix get-opt-relay-cost.sh to work pre-Bedrock upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,5 @@ wards              :; ./scripts/wards.sh $(target)
 time               :; ./scripts/time.sh date="$(date)" stamp="$(stamp)"
 exec-hash          :; ./scripts/hash-exec-copy.sh $(url)
 fund-pause-proxy   :; ./scripts/fund-pause-proxy.sh
+opt-cost           :; ./scripts/get-opt-relay-cost.sh $(spell)
+arb-cost           :; ./scripts/get-arb-relay-cost.sh $(spell)

--- a/scripts/get-arb-relay-cost.sh
+++ b/scripts/get-arb-relay-cost.sh
@@ -2,10 +2,11 @@
 set -e
 
 [[ "$(cast chain --rpc-url="$ETH_RPC_URL")" == "ethlive" ]] || { echo "Please set a Mainnet ETH_RPC_URL"; exit 1; }
+[[ "$1" =~ ^0x[[:xdigit:]]{40}$ ]] || { echo "Please specify the Arbitrum spell address (e.g. 0x852CCBB823D73b3e35f68AD6b14e29B02360FD3d)"; exit 1; }
+L2_SPELL=$1
 
-ARBITRUM_GOERLI_RPC_URL='https://arb1.arbitrum.io/rpc'
+ARBITRUM_MAINNET_RPC_URL='https://arb1.arbitrum.io/rpc'
 
-L2_SPELL='0x852CCBB823D73b3e35f68AD6b14e29B02360FD3d'
 CHANGELOG='0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F'
 NODE_INTERFACE='0x00000000000000000000000000000000000000C8'
 
@@ -18,12 +19,12 @@ INBOX=$(cast call "$L1_GOV_RELAY" "inbox()(address)")
 
 BASE_FEE_SAFETY_FACTOR=20 # Factor by which L1 block.basefee could grow between now and the spell cast time
 
-ARB_GAS_PRICE_BID=$(cast gas-price --rpc-url "$ARBITRUM_GOERLI_RPC_URL")
+ARB_GAS_PRICE_BID=$(cast gas-price --rpc-url "$ARBITRUM_MAINNET_RPC_URL")
 RELAY_CALLDATA=$(
     cast calldata "relay(address,bytes)" "$L2_SPELL" "$(cast calldata "execute()")"
 )
 ARB_MAX_GAS=$(
-    cast estimate --rpc-url "$ARBITRUM_GOERLI_RPC_URL" \
+    cast estimate --rpc-url "$ARBITRUM_MAINNET_RPC_URL" \
     "$NODE_INTERFACE" \
     "estimateRetryableTicket(address,uint256,address,uint256,address,address,bytes)" \
     "$L1_GOV_RELAY" \


### PR DESCRIPTION
`./scripts/get-opt-relay-cost.sh` estimated the gasLimit required to run an Optimism L2 spell based on the how this gasLimit is used in the Bedrock codebase. Unlike Optimism Goerli, Optimism mainnet hasn't yet been migrated to Bedrock (as of Feb 7th, 2023) so this PR adapts the calculation method to match how the gasLimit is used pre-Bedrock.