### PR TITLE
Fix PSM test

### DIFF
--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -1100,12 +1100,14 @@ contract DssSpellTestBase is Config, DssTest {
         assertEq(psm.tin(), tin, _concat("Incorrect-tin-", _ilk));
         assertEq(psm.tout(), tout, _concat("Incorrect-tout-", _ilk));
 
-        // grab ilk line as amount
-        (,,, uint256 amount,) = vat.ilks(_ilk);
-        // if line is big, use smaller amount
-        if (amount > 1000 * (10 ** uint256(token.decimals()))) {
-            amount = 1000 * (10 ** uint256(token.decimals()));
+        // Increase ilk line to allow psm sell even if it is maxed out
+        {
+            (,,, uint256 line,) = vat.ilks(_ilk);
+            vm.prank(pauseProxy);
+            vat.file(_ilk, "line", line + 1000 * RAD);
         }
+
+        uint256 amount = 1000 * (10 ** uint256(token.decimals()));
         _giveTokens(address(token), amount);
 
         // Approvals
@@ -1114,13 +1116,17 @@ contract DssSpellTestBase is Config, DssTest {
 
         // Convert all TOKEN to DAI
         psm.sellGem(address(this), amount);
+        amount = amount * (10 ** (18 - uint256(token.decimals()))); // scale to 18 decimals
         amount -= amount * tin / WAD;
+
         assertEq(token.balanceOf(address(this)), 0, _concat("PSM.sellGem-token-balance-", _ilk));
-        assertEq(dai.balanceOf(address(this)), amount * (10 ** (18 - uint256(token.decimals()))), _concat("PSM.sellGem-dai-balance-", _ilk));
+        assertEq(dai.balanceOf(address(this)), amount, _concat("PSM.sellGem-dai-balance-", _ilk));
 
         // Convert all DAI to TOKEN (Do not do this if the amount is 0)
         if (amount > 0) {
             amount -= _divup(amount * tout, WAD);
+            amount = amount / (10 ** (18 - uint256(token.decimals()))); // scale back to token decimals
+
             psm.buyGem(address(this), amount);
             // There may be some Dai dust left over depending on tout and decimals
             assertTrue(dai.balanceOf(address(this)) < WAD, _concat("PSM.buyGem-dai-balance-", _ilk));
@@ -1128,7 +1134,7 @@ contract DssSpellTestBase is Config, DssTest {
         }
 
         // Dump all dai for next run
-        vat.move(address(this), address(0x0), vat.dai(address(this)));
+        dai.transfer(address(0x0), dai.balanceOf(address(this)));
     }
 
     function _checkDirectIlkIntegration(

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -300,7 +300,7 @@ contract DssSpellTest is DssSpellTestBase {
     }
 
     // leave public for now as this is acting like a config tests
-    function testPSMs() private { // Disabled since some PSMs are maxed out
+    function testPSMs() public {
         _vote(address(spell));
         _scheduleWaitAndCast(address(spell));
         assertTrue(spell.done());
@@ -331,8 +331,8 @@ contract DssSpellTest is DssSpellTestBase {
             ClipAbstract(addr.addr("MCD_CLIP_PSM_PAX_A")),
             addr.addr("PIP_PAX"),
             PsmAbstract(addr.addr("MCD_PSM_PAX_A")),
-            20,  // tin
-            0    // tout
+            0,   // tin
+            100    // tout
         );
 
         _ilk = "PSM-USDC-A";
@@ -346,7 +346,7 @@ contract DssSpellTest is DssSpellTestBase {
             ClipAbstract(addr.addr("MCD_CLIP_PSM_USDC_A")),
             addr.addr("PIP_USDC"),
             PsmAbstract(addr.addr("MCD_PSM_USDC_A")),
-            0,   // tin
+            100,   // tin
             0    // tout
         );
     }


### PR DESCRIPTION
# Description

# Contribution Checklist

- [ ] PR title starts with `(PE-<TICKET_NUMBER>)`
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier override
- [ ] Verify expiration (`30 days` unless otherwise specified)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell `ETH_GAS_LIMIT="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Verify `mainnet` contract on etherscan
- [ ] Change test to use mainnet spell address and deploy timestamp
- [ ] Run `make archive-spell` or `make date="YYYY-MM-DD" archive-spell` to make an archive directory and copy `DssSpell.sol`, `DssSpell.t.sol`, `DssSpell.t.base.sol`, and `DssSpellCollateralOnboarding.sol`
- [ ] `squash and merge` this PR
