### PR TITLE
Feature: add `no-match` option to `make test-forge` / Refactor: use `make test` instead of `make test-forge` in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,6 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: Run tests
-        run: make test-forge
+        run: make test
         env:
           ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all                  :; DAPP_LIBRARIES=' lib/dss-exec-lib/src/DssExecLib.sol:Dss
 clean                :; forge clean
                         # Usage example: make test match=SpellIsCast
 test                 :; ./scripts/test-dssspell-forge.sh match="$(match)" block="$(block)"
-test-forge           :; ./scripts/test-dssspell-forge.sh match="$(match)" block="$(block)"
+test-forge           :; ./scripts/test-dssspell-forge.sh match="$(match)" no-match="$(no-match)" block="$(block)"
 estimate             :; ./scripts/estimate-deploy-gas.sh
 deploy               :; ./scripts/deploy.sh
 deploy-info          :; ./scripts/get-deploy-info.sh tx=$(tx)

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ all                  :; DAPP_LIBRARIES=' lib/dss-exec-lib/src/DssExecLib.sol:Dss
                          dapp --use solc:0.8.16 build
 clean                :; forge clean
                         # Usage example: make test match=SpellIsCast
-test                 :; ./scripts/test-dssspell-forge.sh match="$(match)" block="$(block)"
-test-forge           :; ./scripts/test-dssspell-forge.sh match="$(match)" no-match="$(no-match)" block="$(block)"
+test                 :; ./scripts/test-dssspell-forge.sh no-match="$(no-match)" match="$(match)" block="$(block)"
+test-forge           :; ./scripts/test-dssspell-forge.sh no-match="$(no-match)" match="$(match)" block="$(block)"
 estimate             :; ./scripts/estimate-deploy-gas.sh
 deploy               :; ./scripts/deploy.sh
 deploy-info          :; ./scripts/get-deploy-info.sh tx=$(tx)

--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -10,6 +10,7 @@ do
 
     case "$KEY" in
             match)      MATCH="$VALUE" ;;
+            no-match)   NO_MATCH="$VALUE" ;;
             block)      BLOCK="$VALUE" ;;
             *)
     esac
@@ -18,16 +19,20 @@ done
 DSS_EXEC_LIB=$(< DssExecLib.address)
 echo "Using DssExecLib at: $DSS_EXEC_LIB"
 export FOUNDRY_LIBRARIES="lib/dss-exec-lib/src/DssExecLib.sol:DssExecLib:$DSS_EXEC_LIB"
-export FOUNDRY_OPTIMIZER=true
+export FOUNDRY_OPTIMIZER=false
 export FOUNDRY_OPTIMIZER_RUNS=200
 export FOUNDRY_ROOT_CHAINID=1
 
-if [[ -z "$MATCH" && -z "$BLOCK" ]]; then
-    forge test --fork-url "$ETH_RPC_URL"
-elif [[ -z "$BLOCK" ]]; then
-    forge test --fork-url "$ETH_RPC_URL" --match-test "$MATCH" -vvv
-elif [[ -z "$MATCH" ]]; then
-    forge test --fork-url "$ETH_RPC_URL" --fork-block-number "$BLOCK"
-else
-    forge test --fork-url "$ETH_RPC_URL" --match-test "$MATCH" --fork-block-number "$BLOCK" -vvv
+EXTRA_ARGS=''
+
+if [[ -n "$MATCH" ]]; then
+    EXTRA_ARGS="${EXTRA_ARGS} -vvv --match-test ${MATCH}"
+elif [[ -n "$NO_MATCH" ]]; then
+    EXTRA_ARGS="${EXTRA_ARGS} -vvv --no-match-test ${NO_MATCH}"
 fi
+
+if [[ -n "$BLOCK" ]]; then
+    EXTRA_ARGS="${EXTRA_ARGS} --fork-block-number ${BLOCK}"
+fi
+
+forge test --fork-url "$ETH_RPC_URL" $EXTRA_ARGS

--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -23,7 +23,7 @@ export FOUNDRY_OPTIMIZER=false
 export FOUNDRY_OPTIMIZER_RUNS=200
 export FOUNDRY_ROOT_CHAINID=1
 
-local TEST_ARGS=''
+TEST_ARGS=''
 
 if [[ -n "$MATCH" ]]; then
     TEST_ARGS="${TEST_ARGS} -vvv --match-test ${MATCH}"

--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -19,7 +19,7 @@ done
 DSS_EXEC_LIB=$(< DssExecLib.address)
 echo "Using DssExecLib at: $DSS_EXEC_LIB"
 export FOUNDRY_LIBRARIES="lib/dss-exec-lib/src/DssExecLib.sol:DssExecLib:$DSS_EXEC_LIB"
-export FOUNDRY_OPTIMIZER=false
+export FOUNDRY_OPTIMIZER=true
 export FOUNDRY_OPTIMIZER_RUNS=200
 export FOUNDRY_ROOT_CHAINID=1
 

--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -23,16 +23,16 @@ export FOUNDRY_OPTIMIZER=false
 export FOUNDRY_OPTIMIZER_RUNS=200
 export FOUNDRY_ROOT_CHAINID=1
 
-EXTRA_ARGS=''
+local TEST_ARGS=''
 
 if [[ -n "$MATCH" ]]; then
-    EXTRA_ARGS="${EXTRA_ARGS} -vvv --match-test ${MATCH}"
+    TEST_ARGS="${TEST_ARGS} -vvv --match-test ${MATCH}"
 elif [[ -n "$NO_MATCH" ]]; then
-    EXTRA_ARGS="${EXTRA_ARGS} -vvv --no-match-test ${NO_MATCH}"
+    TEST_ARGS="${TEST_ARGS} -vvv --no-match-test ${NO_MATCH}"
 fi
 
 if [[ -n "$BLOCK" ]]; then
-    EXTRA_ARGS="${EXTRA_ARGS} --fork-block-number ${BLOCK}"
+    TEST_ARGS="${TEST_ARGS} --fork-block-number ${BLOCK}"
 fi
 
-forge test --fork-url "$ETH_RPC_URL" $EXTRA_ARGS
+forge test --fork-url "$ETH_RPC_URL" $TEST_ARGS


### PR DESCRIPTION
This is a port from [spells-goerli#220](https://github.com/makerdao/spells-goerli/pull/220). See the original PR for details.
