### PR TITLE
feat: standarizing chainlog changes [PoC]

### DIFF
--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -23,6 +23,7 @@ import "./test/rates.sol";
 import "./test/addresses_mainnet.sol";
 import "./test/addresses_deployers.sol";
 import "./test/addresses_wallets.sol";
+import "./test/actions.sol";
 import "./test/config.sol";
 
 import {DssSpell} from "./DssSpell.sol";
@@ -156,7 +157,7 @@ interface FlapperMomAbstract {
     function stop() external;
 }
 
-contract DssSpellTestBase is Config, DssTest {
+contract DssSpellTestBase is Config, Actions, DssTest {
     Rates         rates = new Rates();
     Addresses      addr = new Addresses();
     Deployers deployers = new Deployers();
@@ -1987,6 +1988,10 @@ contract DssSpellTestBase is Config, DssTest {
 
         // Dump all dai for next run
         vat.move(address(this), address(0x0), vat.dai(address(this)));
+    }
+
+    function _skipTest(bool _skip) internal {
+        address(vm).call(abi.encodeWithSignature("skip(bool)", _skip));
     }
 
 }

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -104,6 +104,12 @@ contract DssSpellTest is DssSpellTestBase {
     }
 
     function testAuth() public {
+        _skipTest(
+            chainlogAdds.length == 0 &&
+            chainlogRemoves.length == 0 &&
+            chainlogUpdates.length == 0
+        );
+
         _checkAuth(false);
     }
 
@@ -120,6 +126,12 @@ contract DssSpellTest is DssSpellTestBase {
     }
 
     function testChainlogVersionBump() public {
+        _skipTest(
+            chainlogAdds.length == 0 &&
+            chainlogRemoves.length == 0 &&
+            chainlogUpdates.length == 0
+        );
+
         _testChainlogVersionBump();
     }
 
@@ -239,17 +251,21 @@ contract DssSpellTest is DssSpellTestBase {
         //assertEq(OsmAbstract(0xF15993A5C5BE496b8e1c9657Fd2233b579Cd3Bc6).wards(ORACLE_WALLET01), 1);
     }
 
-    function testRemoveChainlogValues() private { // make private to disable
+    function testRemoveChainlogValues() public {
+        _skipTest(chainlogRemoves.length == 0);
+
         _vote(address(spell));
         _scheduleWaitAndCast(address(spell));
         assertTrue(spell.done());
 
-        try chainLog.getAddress("MCD_CAT") {
-            assertTrue(false);
-        } catch Error(string memory errmsg) {
-            assertTrue(_cmpStr(errmsg, "dss-chain-log/invalid-key"));
-        } catch {
-            assertTrue(false);
+        for(uint256 _i; _i < chainlogRemoves.length; _i++) {
+            try chainLog.getAddress(chainlogRemoves[_i].name) {
+                assertTrue(false);
+            } catch Error(string memory errmsg) {
+                assertTrue(_cmpStr(errmsg, "dss-chain-log/invalid-key"));
+            } catch {
+                assertTrue(false);
+            }
         }
     }
 

--- a/src/test/actions.sol
+++ b/src/test/actions.sol
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2021 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.8.16;
+
+contract Actions {
+
+    struct ChainlogAdd {
+        bytes32 name;
+        address addr;
+    }
+
+    struct ChainlogRemove {
+        bytes32 name;
+    }
+
+    struct ChainlogUpdate {
+        bytes32 name;
+        address oldAddr;
+        address addr;
+    }
+
+    ChainlogAdd[] public chainlogAdds;
+    ChainlogRemove[] public chainlogRemoves;
+    ChainlogUpdate[] public chainlogUpdates;
+
+    constructor() {
+
+    }
+
+}


### PR DESCRIPTION
The objective of this PoC PR is to standarize common chainlog actions such as `add`, `remove`, and `update`, and have a way of skipping tests should none of these actions be present.

The PR adds a file name `actions.sol`, in which the crafter will have to implement the expected actions before starting to write the DssSpell contract, making the tests be executed only when these tests are present, avoiding using `private / public` logic to disable and enable tests arbitrarily, and adding more steps on the pe-checklist.

A separate test could be run in order to check that if the chainlog did have some change (such as change in length, or in any given address) and any of the addresses was not properly declared, the test would fail.

<img width="421" alt="image" src="https://github.com/makerdao/spells-mainnet/assets/84595958/65bc30f6-fb0d-46a0-be9f-18f97492f12b">