### PR TITLE
refactor: standarize testing for dai and mkr actions [PoC]

### DIFF
--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -272,6 +272,11 @@ contract DssSpellTestBase is Config, Actions, DssTest {
         return string(bytesArray);
     }
 
+    function _skipTest(bool _skip) internal {
+        (bool success, ) = address(vm).call(abi.encodeWithSignature("skip(bool)", _skip));
+        success;
+    }
+
     // 10^-5 (tenth of a basis point) as a RAY
     uint256 TOLERANCE = 10 ** 22;
 
@@ -1989,12 +1994,6 @@ contract DssSpellTestBase is Config, Actions, DssTest {
 
         // Dump all dai for next run
         vat.move(address(this), address(0x0), vat.dai(address(this)));
-    }
-
-    function _skipTest(bool _skip) internal {
-        // NOTE: Using low-level calls until vm supports skip(bool) method
-        (bool success, ) = address(vm).call(abi.encodeWithSignature("skip(bool)", _skip));
-        success;
     }
 
 }

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -23,6 +23,7 @@ import "./test/rates.sol";
 import "./test/addresses_mainnet.sol";
 import "./test/addresses_deployers.sol";
 import "./test/addresses_wallets.sol";
+import "./test/actions.sol";
 import "./test/config.sol";
 
 import {DssSpell} from "./DssSpell.sol";
@@ -156,7 +157,7 @@ interface FlapperMomAbstract {
     function stop() external;
 }
 
-contract DssSpellTestBase is Config, DssTest {
+contract DssSpellTestBase is Config, Actions, DssTest {
     Rates         rates = new Rates();
     Addresses      addr = new Addresses();
     Deployers deployers = new Deployers();
@@ -328,6 +329,7 @@ contract DssSpellTestBase is Config, DssTest {
             // even if mainnet has already scheduled/cast the spell
             vm.makePersistent(address(rates));
             vm.makePersistent(address(addr));
+            vm.makePersistent(address(wallets));
             vm.makePersistent(address(deployers));
             vm.rollFork(spellValues.deployed_spell_block);
 
@@ -1987,6 +1989,12 @@ contract DssSpellTestBase is Config, DssTest {
 
         // Dump all dai for next run
         vat.move(address(this), address(0x0), vat.dai(address(this)));
+    }
+
+    function _skipTest(bool _skip) internal {
+        // NOTE: Using low-level calls until vm supports skip(bool) method
+        (bool success, ) = address(vm).call(abi.encodeWithSignature("skip(bool)", _skip));
+        success;
     }
 
 }

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -403,9 +403,9 @@ contract DssSpellTest is DssSpellTestBase {
         assertEq(vest.cap(), 1 * MILLION * WAD / 30 days, "testVestDAI/invalid-cap");
 
         // Check that all streams added in this spell are tested
-        assertEq(vest.ids(), prevStreamCount + daiStreams.length, "testVestDAI/not-all-streams-tested");
+        assertEq(vest.ids(), prevStreamCount + DAI_STREAMS_COUNT, "testVestDAI/not-all-streams-tested");
 
-        for (uint256 i = 0; i < daiStreams.length; i++) {
+        for (uint256 i = 0; i < DAI_STREAMS_COUNT; i++) {
             uint256 streamId = prevStreamCount + i + 1;
             address wallet = wallets.addr(daiStreams[i].wallet);
 

--- a/src/test/actions.sol
+++ b/src/test/actions.sol
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: © 2021 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.8.16;
+
+contract Actions {
+
+    struct Stream {
+        uint256 streamId;
+        bytes32 wallet;       // name of the wallet
+        uint256 rewardAmount; // units
+        uint256 start;
+        uint256 cliff;
+        uint256 end;
+        uint256 durationDays;
+        address manager;
+        uint256 isRestricted;
+        uint256 claimedAmount;
+    }
+
+    struct Payee {
+        bytes32 wallet;       // name of the payee
+        uint256 amount;       // units
+    }
+
+    struct Yank {
+        uint256 streamId;
+        bytes32 wallet;
+        uint256 finPlanned;   // the planned fin of the stream (via variable defined below)
+    }
+
+    Stream[] public daiStreams;
+    Stream[] public mkrStreams;
+    Payee[] public daiPayees;
+    Payee[] public mkrPayees;
+    Yank[] public daiYanks;
+    Yank[] public mkrYanks;
+
+
+    // Expected global actions
+    uint256 immutable DAI_STREAMS_COUNT;
+    uint256 immutable DAI_PAYEES_COUNT;
+    uint256 immutable DAI_YANKS_COUNT;
+
+    uint256 immutable MKR_STREAMS_COUNT;
+    uint256 immutable MKR_PAYEES_COUNT;
+    uint256 immutable MKR_YANKS_COUNT;
+
+    uint256 immutable DAI_SUM_PAYMENTS;
+    uint256 immutable MKR_SUM_PAYMENTS;
+
+    // Provide human-readable names for timestamps
+    uint256 DEC_01_2023 = 1701385200;
+    uint256 MARCH_31_2024 = 1711929599;
+    uint256 NOV_30_2024 = 1733007599;
+
+    constructor() {
+        // Initialize the amount of streams and payees for MKR and DAI
+        DAI_STREAMS_COUNT = 1;
+        DAI_PAYEES_COUNT = 1;
+        DAI_YANKS_COUNT = 2;
+
+        MKR_STREAMS_COUNT = 1;
+        MKR_PAYEES_COUNT = 0;
+        MKR_YANKS_COUNT = 0;
+
+        // Fill the number with the value from exec doc.
+        DAI_SUM_PAYMENTS = 201_738;
+        MKR_SUM_PAYMENTS = 0;
+
+        // For each new stream, provide Stream object
+        daiStreams.push(Stream({
+            streamId:      38,
+            wallet:        "ECOSYSTEM_FACILITATOR",
+            rewardAmount:  504_000,
+            start:         DEC_01_2023,
+            cliff:         DEC_01_2023,
+            end:           NOV_30_2024,
+            durationDays:  366 days,
+            manager:       address(0),
+            isRestricted:  1,
+            claimedAmount: 0
+        }));
+
+        mkrStreams.push(Stream({
+            streamId:      44,
+            wallet:        "ECOSYSTEM_FACILITATOR",
+            rewardAmount:  216,
+            start:         DEC_01_2023,
+            cliff:         DEC_01_2023,
+            end:           NOV_30_2024,
+            durationDays:  366 days,
+            manager:       address(0),
+            isRestricted:  1,
+            claimedAmount: 0
+        }));
+
+        // For each new payee, provide Payee object
+        daiPayees.push(Payee({
+            wallet: "BLOCKTOWER_WALLET_2",
+            amount: 201_738
+        }));
+
+        // For each new yank, provide Yank object
+        daiYanks.push(Yank({
+            streamId: 18,
+            wallet: "TECH",
+            finPlanned: MARCH_31_2024
+        }));
+
+        daiYanks.push(Yank({
+            streamId: 19,
+            wallet: "STEAKHOUSE",
+            finPlanned: MARCH_31_2024
+        }));
+    }
+
+}


### PR DESCRIPTION
This PR adds another PoC, in the same rationale of #375, but for more common actions such as DAI and MKR streams, payments, and yanks. The ultimate goal is to reduce what developer needs to touch in DssSpell.t.sol, and move the common actions (such as payments) to a separate and more auditable testing file, while avoiding [disabling and enabling tests](https://github.com/makerdao/pe-checklists/blob/8e075342d60fac1621673768a76ad797107fbee7/spell/spell-reviewer-mainnet-checklist.md?plain=1#L316) that are crucial for the correct check on these actions. 

The workflow checks (same as previous tests):
- correct length of arrays (e.g. expected amounts of Payees)
- correct sum of payments
- adds the dates all together (and avoids repeating them for different scopes)

The advantages of this process rationale:
- adds no smart-contract security overhead, other than a correct file import at testing
- forces (by process) beneficiaries to be declared by name (and be added to `addresses_deployers.sol`)
- a `[SKIP]` test is easier to detect than a non-existing test
- less line modifications in sparsed lines of `DssSpell.t.sol`
- standarize payments and vesting testing [cleanup patterns](https://github.com/makerdao/pe-checklists/blob/8e075342d60fac1621673768a76ad797107fbee7/spell/spell-crafter-mainnet-workflow.md?plain=1#L25) 

Given that previous spell has no MKR payments or yanks, the test output looks like this:
<img width="487" alt="image" src="https://github.com/makerdao/spells-mainnet/assets/84595958/aa9e9c70-86ef-4c04-acba-8c6e0f41dc1e">

As you replied in #375, the rule of thumb is to make tests as simple as possible, i agree, there's little advantage in that one (as it touches the changelog, and perhaps needs other process), but perhaps this approach on [very common tasks ](https://github.com/makerdao/pe-checklists/blob/8e075342d60fac1621673768a76ad797107fbee7/spell/spell-crafter-mainnet-workflow.md?plain=1#L116C1-L117C1) could be a bit more beneficial for the testing process. 