### PR TITLE
feat: adding codebase/deployed tests scenarios [PoC]

### DIFF
--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -52,7 +52,7 @@ interface RwaLiquidationOracleLike {
     function ilks(bytes32) external view returns (string memory, address, uint48 toc, uint48 tau);
 }
 
-contract DssSpellTest is DssSpellTestBase {
+abstract contract DssSpellTest is DssSpellTestBase {
     string         config;
     RootDomain     rootDomain;
     OptimismDomain optimismDomain;
@@ -103,16 +103,12 @@ contract DssSpellTest is DssSpellTestBase {
         _testUseEta();
     }
 
-    function testAuth() public {
+    function testAuth() private { // NOTE: disabling for performance reasons #374
         _checkAuth(false);
     }
 
-    function testAuthInSources() public {
+    function testAuthInSources() private { // NOTE: disabling for performance reasons #374
         _checkAuth(true);
-    }
-
-    function testBytecodeMatches() public {
-        _testBytecodeMatches();
     }
 
     function testChainlogValues() public {
@@ -929,3 +925,14 @@ contract DssSpellTest is DssSpellTestBase {
         assertEq(spot, 1_500_000_000 * RAY, "RWA014: Bad spot value after bump()");
     }
 }
+
+contract DssSpellTestDeployed is DssSpellTest, DssSpellTestDeployedBase {  // NOTE: make abstract to disable
+
+    // NOTE: moving test to be only run on forked scope
+    function testBytecodeMatches() public {
+        _testBytecodeMatches();
+    }
+
+}
+
+contract DssSpellTestCodebase is DssSpellTest, DssSpellTestCodebaseBase {} // NOTE: make abstract to disable

--- a/src/test/starknet.t.sol
+++ b/src/test/starknet.t.sol
@@ -87,7 +87,7 @@ interface DaiLike {
     function allowance(address, address) external view returns (uint256);
 }
 
-contract StarknetTests is DssSpellTestBase, ConfigStarknet {
+abstract contract StarknetTests is DssSpellTestBase, ConfigStarknet { // NOTE: disabling whole test for PoC PR
 
     event LogMessageToL2(
             address indexed fromAddress,


### PR DESCRIPTION
The objective of this PoC strategy, is to enable both testing scenarios while developing and debugging the spells. Benefitting from contract inheritance, the testing codebase would be exactly the same for one or another, without requiring to multiply codebase (which is a pain to maintain). 

![image](https://github.com/makerdao/spells-mainnet/assets/84595958/4406c8c5-678a-48f0-901a-5ce6d69e09f8)

When working on a spell, a developer may need to make some changes to debug what's happening on chain, and the current workflow for him is to change the deployed address to `address(0)` to declare that the test suite should read (and deploy) the codebase spell, instead of reading the forked one.

Forgetting to delete this address, could result in a frustrating DX experience, while developer is making changes to the codebase, but no changes in tests appear. Instead, with the current PoC, the deployer could separate which test to perform, doing either `make test match=Deployed` or `make test match=Codebase`, or enable the CI to run different scopes at different steps.

Also, this strategy, could benefit from running certain tests only when it makes sense to run, instead of hacking that test to pass even when it's run on the Codebase, for example, `testBytecode` in this PoC is set to run **only** on the Deployed scope (notice: it has 23 tests, while Codebase has 22).

![image](https://github.com/makerdao/spells-mainnet/assets/84595958/55858e12-428f-42a9-99cc-6f6d8f2d6980)

Of course, this needs to be addressed after optimizing the tests in such a way that they [don't last minutes](https://mirror.xyz/dewiz.xyz/q4C9GwxB6Arc-kw_5OsEKD9dGXrn-jde36h8Vyhe12s), but afterwards, the benefits for the developer or the CI process could overweight the waiting period of running these "duplicated" tests.