### PR TITLE
Replace dapp tools with foundry for spell flattening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ estimate             :; ./scripts/estimate-deploy-gas.sh
 deploy               :; ./scripts/deploy.sh
 deploy-info          :; ./scripts/get-deploy-info.sh tx=$(tx)
 verify               :; ./scripts/verify.py DssSpell $(addr)
-flatten              :; hevm flatten --source-file "src/DssSpell.sol" > out/flat.sol
+flatten              :; forge flatten src/DssSpell.sol > out/flat.sol
 diff-deployed-spell  :; ./scripts/diff-deployed-dssspell.sh $(spell)
 check-deployed-spell :; ./scripts/check-deployed-dssspell.sh
 cast-on-tenderly     :; cd ./scripts/cast-on-tenderly/ && npm i && npm start -- $(spell); cd -

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -53,8 +53,8 @@ if contract_path == '':
     exit('contract name not found.')
 
 print('Obtaining chain... ')
-seth_chain = subprocess.run(['seth', 'chain'], capture_output=True)
-chain = seth_chain.stdout.decode('ascii').replace('\n', '')
+cast_chain = subprocess.run(['cast', 'chain'], capture_output=True)
+chain = cast_chain.stdout.decode('ascii').replace('\n', '')
 print(chain)
 
 text_metadata = content['contracts'][contract_path][contract_name]['metadata']
@@ -75,9 +75,8 @@ action = 'verifysourcecode'
 code_format = 'solidity-single-file'
 
 flatten = subprocess.run([
-    'hevm',
+    'forge',
     'flatten',
-    '--source-file',
     contract_path
 ], capture_output=True)
 code = flatten.stdout.decode('utf-8')


### PR DESCRIPTION
# Description

This PR implements minimal changes required to remove dependency on [dapp.tools](https://dapp.tools/) and replace it with foundry commands (ie `hevm` with `forge`, `seth` with `cast`). 

In order to try out this PR, one have to install a [foundry build](https://github.com/foundry-rs/foundry/releases/tag/nightly-2cb875799419c907cc3709e586ece2559e6b340e) containing [the fix](https://github.com/foundry-rs/foundry/pull/6936) with rewritten implementation of the flattening logic, eg:

```
foundryup --version nightly-2cb875799419c907cc3709e586ece2559e6b340e
```

Or a later version that also includes this major fix.

