### PR TITLE
Mainnet spell 2024-03-20

### DIFF
--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -19,20 +19,12 @@ pragma solidity 0.8.16;
 import "dss-exec-lib/DssExec.sol";
 import "dss-exec-lib/DssAction.sol";
 
-interface PauseLike {
-    function setDelay(uint256 delay_) external;
-}
-
-interface ProxyLike {
-    function exec(address target, bytes calldata args) external payable returns (bytes memory out);
-}
-
 contract DssSpellAction is DssAction {
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
-    // Hash: cast keccak -- "$(wget https://raw.githubusercontent.com/makerdao/community/298421e90b51a0459148b3d41c558d291eeb0b1f/governance/votes/Executive%20vote%20-%20March%208%2C%202024.md -q -O - 2>/dev/null)"
+    // Hash: cast keccak -- "$(wget TODO -q -O - 2>/dev/null)"
     string public constant override description =
-        "2024-03-08 MakerDAO Executive Spell | Hash: 0x94608a6337c99fc128873534fb5e2dbced316e9212500dfc53b989d08ad3dbdd";
+        "2024-03-20 MakerDAO Executive Spell | Hash: TODO";
 
     // Set office hours according to the summary
     function officeHours() public pure override returns (bool) {
@@ -50,79 +42,8 @@ contract DssSpellAction is DssAction {
     //    https://ipfs.io/ipfs/QmVp4mhhbwWGTfbh2BzwQB9eiBrQBKiqcPRZCaAxNUaar6
     //
     // uint256 internal constant X_PCT_RATE = ;
-    uint256 internal constant FIFTEEN_PCT_RATE               = 1000000004431822129783699001;
-    uint256 internal constant FIFTEEN_PT_TWO_FIVE_PCT_RATE   = 1000000004500681640286189459;
-    uint256 internal constant FIFTEEN_PT_SEVEN_FIVE_PCT_RATE = 1000000004637953682059597074;
-    uint256 internal constant SIXTEEN_PCT_RATE               = 1000000004706367499604668374;
-    uint256 internal constant SIXTEEN_PT_TWO_FIVE_PCT_RATE   = 1000000004774634032180348552;
-    uint256 internal constant SIXTEEN_PT_FIVE_PCT_RATE       = 1000000004842753912590664903;
-    uint256 internal constant SIXTEEN_PT_SEVEN_FIVE_PCT_RATE = 1000000004910727769570159235;
-    uint256 internal constant SEVENTEEN_PT_TWO_FIVE_PCT_RATE = 1000000005046239908035965222;
 
-    // ---------- Math ----------
-    uint256 internal constant MILLION = 10 ** 6;
-    uint256 internal constant BILLION = 10 ** 9;
-
-    // ---------- Contracts ----------
-    address internal immutable MCD_PAUSE = DssExecLib.getChangelogAddress("MCD_PAUSE");
-
-    // ---------- Trigger Spark Proxy Spell ----------
-    // Spark Proxy: https://github.com/marsfoundation/sparklend/blob/d42587ba36523dcff24a4c827dc29ab71cd0808b/script/output/1/primary-sce-latest.json#L2
-    address internal constant SPARK_PROXY = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;
-    address internal constant SPARK_SPELL = 0xFc72De9b361dB85F1d126De9cac51A1aEe8Ce126;
-
-    function actions() public override {
-        // ---------- DSR Change ----------
-        // Forum: https://forum.makerdao.com/t/accelerated-proposal-rate-system-gsm-delay-psm-usdc-a-ttl-changes/23824
-
-        // Increase the DSR by 10% from 5% to 15%
-        DssExecLib.setDSR(FIFTEEN_PCT_RATE, /* doDrip = */ true);
-
-        // ---------- Stability Fee Changes ----------
-        // Forum: https://forum.makerdao.com/t/accelerated-proposal-rate-system-gsm-delay-psm-usdc-a-ttl-changes/23824
-
-        // Increase the ETH-A Stability Fee by 8.84% from 6.41% to 15.25%
-        DssExecLib.setIlkStabilityFee("ETH-A", FIFTEEN_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
-
-        // Increase the ETH-B Stability Fee by 8.84% from 6.91% to 15.75%
-        DssExecLib.setIlkStabilityFee("ETH-B", FIFTEEN_PT_SEVEN_FIVE_PCT_RATE, /* doDrip = */ true);
-
-        // Increase the ETH-C Stability Fee by 8.84% from 6.16% to 15%
-        DssExecLib.setIlkStabilityFee("ETH-C", FIFTEEN_PCT_RATE, /* doDrip = */ true);
-
-        // Increase the WSTETH-A Stability Fee by 9.6% from 6.65% to 16.25%
-        DssExecLib.setIlkStabilityFee("WSTETH-A", SIXTEEN_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
-
-        // Increase the WSTETH-B Stability Fee by 9.6% from 6.4% to 16%
-        DssExecLib.setIlkStabilityFee("WSTETH-B", SIXTEEN_PCT_RATE, /* doDrip = */ true);
-
-        // Increase the WBTC-A Stability Fee by 10.07% from 6.68% to 16.75%
-        DssExecLib.setIlkStabilityFee("WBTC-A", SIXTEEN_PT_SEVEN_FIVE_PCT_RATE, /* doDrip = */ true);
-
-        // Increase the WBTC-B Stability Fee by 10.07% from 7.18% to 17.25%
-        DssExecLib.setIlkStabilityFee("WBTC-B", SEVENTEEN_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
-
-        // Increase the WBTC-C Stability Fee by 10.07% from 6.43% to 16.5%
-        DssExecLib.setIlkStabilityFee("WBTC-C", SIXTEEN_PT_FIVE_PCT_RATE, /* doDrip = */ true);
-
-        // ---------- GSM Change ----------
-        // Forum: https://forum.makerdao.com/t/accelerated-proposal-rate-system-gsm-delay-psm-usdc-a-ttl-changes/23824
-
-        // Decrease the GSM Delay by 32 hours from 48 hours to 16 hours
-        PauseLike(MCD_PAUSE).setDelay(16 hours);
-
-        // ---------- USDC PSM ttl Change ----------
-        // Forum: https://forum.makerdao.com/t/accelerated-proposal-rate-system-gsm-delay-psm-usdc-a-ttl-changes/23824
-
-        // Decrease the ttl by 12 hours from 24 hours to 12 hours
-        DssExecLib.setIlkAutoLineParameters("PSM-USDC-A", 10 * BILLION, 400 * MILLION, 12 hours);
-
-        // ---------- Trigger Spark Proxy Spell ----------
-        // Forum: https://forum.makerdao.com/t/accelerated-proposal-rate-system-gsm-delay-psm-usdc-a-ttl-changes/23824
-
-        // Trigger Spark Proxy Spell at 0xFc72De9b361dB85F1d126De9cac51A1aEe8Ce126
-        ProxyLike(SPARK_PROXY).exec(SPARK_SPELL, abi.encodeWithSignature("execute()"));
-    }
+    function actions() public override {}
 }
 
 contract DssSpell is DssExec {

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -820,9 +820,9 @@ contract DssSpellTest is DssSpellTestBase {
 
     // SPARK TESTS
 
-    function testSparkSpellIsExecuted() public { // add the `skipped` modifier to skip
+    function testSparkSpellIsExecuted() public skipped { // add the `skipped` modifier to skip
         address SPARK_PROXY = addr.addr('SPARK_PROXY');
-        address SPARK_SPELL = 0xFc72De9b361dB85F1d126De9cac51A1aEe8Ce126;
+        address SPARK_SPELL = address(0);
 
         vm.expectCall(
             SPARK_PROXY,

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -86,7 +86,8 @@ contract Config {
     function setValues(address chief) public {
         // Add spells if there is a need to test prior to their cast() functions
         // being called on-chain. They will be executed in order from index 0.
-        address[] memory prevSpells = new address[](0);
+        address[] memory prevSpells = new address[](1);
+        prevSpells[0] = 0xD8D60b7A9998098261DF5175B5b0Fb567CD0Fb1A; // 2024-03-06 spell
 
         //
         // Values for spell-specific parameters
@@ -112,7 +113,7 @@ contract Config {
         afterSpell.vow_bump              = 50 * THOUSAND;  // In whole Dai units
         afterSpell.vow_hump_min          = 50 * MILLION;   // In whole Dai units
         afterSpell.vow_hump_max          = 50 * MILLION;   // In whole Dai units
-        afterSpell.flap_hop              = 26_280 seconds; // In seconds
+        afterSpell.flap_hop              = 19_710 seconds; // In seconds
         afterSpell.flap_want             = 9800;           // In basis points
         afterSpell.dog_Hole              = 150 * MILLION;  // In whole Dai units
         afterSpell.esm_min               = 150 * THOUSAND; // In whole MKR units
@@ -280,7 +281,7 @@ contract Config {
         afterSpell.collaterals["WBTC-A"] = CollateralValues({
             aL_enabled:   true,
             aL_line:      500 * MILLION,
-            aL_gap:       2 * MILLION,
+            aL_gap:       4 * MILLION,
             aL_ttl:       24 hours,
             line:         0,
             dust:         7_500,
@@ -330,7 +331,7 @@ contract Config {
         afterSpell.collaterals["WBTC-C"] = CollateralValues({
             aL_enabled:   true,
             aL_line:      500 * MILLION,
-            aL_gap:       2 * MILLION,
+            aL_gap:       8 * MILLION,
             aL_ttl:       24 hours,
             line:         0,
             dust:         3_500,

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -92,9 +92,9 @@ contract Config {
         // Values for spell-specific parameters
         //
         spellValues = SpellValues({
-            deployed_spell:         address(0xdD0AB42848b5609ded083459110d2e38483E0859), // populate with deployed spell if deployed
-            deployed_spell_created: 1709920511, // use `make deploy-info tx=<deployment-tx>` to obtain the timestamp
-            deployed_spell_block:   19392071,   // use `make deploy-info tx=<deployment-tx>` to obtain the block number
+            deployed_spell:         address(0), // populate with deployed spell if deployed
+            deployed_spell_created: 0, // use `make deploy-info tx=<deployment-tx>` to obtain the timestamp
+            deployed_spell_block:   0,   // use `make deploy-info tx=<deployment-tx>` to obtain the block number
             previous_spells:        prevSpells, // older spells to ensure are executed first
             office_hours_enabled:   false,      // true if officehours is expected to be enabled in the spell
             expiration_threshold:   30 days     // Amount of time before spell expires

--- a/src/test/starknet.t.sol
+++ b/src/test/starknet.t.sol
@@ -37,7 +37,7 @@ contract ConfigStarknet {
 
         starknetValues = StarknetValues({
             l2_spell:                  0,  // Set to zero if no spell is set.
-            core_implementation:       0x16938E4b59297060484Fa56a12594d8D6F4177e8, // Updated 2023-05-24
+            core_implementation:       0x6E0aCfDC3cf17A7f99ed34Be56C3DFb93F464e24, // As of 2024-03-14
             dai_bridge_isOpen:         1,                     // 1 open, 0 closed
             dai_bridge_ceiling:        5_000_000 * WAD,       // wei
             dai_bridge_maxDeposit:     type(uint256).max,     // wei


### PR DESCRIPTION
# Description
This PR implements 2024-03-20 mainnet spell according to the [relevant executive sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw/edit#gid=24607137)

# Contribution Checklist

- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier override
- [ ] Verify expiration (`30 days` unless otherwise specified)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell `ETH_GAS_LIMIT="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Verify `mainnet` contract on etherscan
- [ ] Change test to use mainnet spell address and deploy timestamp
- [ ] Run `make archive-spell` or `make date="YYYY-MM-DD" archive-spell` to make an archive directory and copy `DssSpell.sol`, `DssSpell.t.sol`, `DssSpell.t.base.sol`, and `DssSpellCollateralOnboarding.sol`
- [ ] `squash and merge` this PR
