### PR TITLE
Mainnet spell 2024-04-18

### DIFF
--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -121,8 +121,8 @@ contract DssSpellAction is DssAction {
         // Pipkin - 13.89 MKR - 0x0E661eFE390aE39f90a58b04CF891044e56DEDB7
         MKR.transfer(PIPKIN, 13.89 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
 
-        // JAG - 13.89 MKR - 0x58D1ec57E4294E4fe650D1CB12b96AE34349556f
-        MKR.transfer(JAG, 13.89 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+        // JAG - 9.08 MKR - 0x58D1ec57E4294E4fe650D1CB12b96AE34349556f
+        MKR.transfer(JAG, 9.08 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
 
         // UPMaker - 12.93 MKR - 0xbB819DF169670DC71A16F58F55956FE642cc6BcD
         MKR.transfer(UPMAKER, 12.93 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -90,7 +90,7 @@ contract DssSpellAction is DssAction {
 
     // ---------- Whitelist new address in the RWA015-A output conduit ----------
     address internal constant RWA015_A_CUSTODY_2                 = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
-    RwaOutputConduitLike internal immutable RWA015_A_OUTPUT_CONDUIT = RwaOutputConduitLike(DssExecLib.getChangelogAddress("RWA015_A_OUTPUT_CONDUIT"));
+    address internal constant RWA015_A_OUTPUT_CONDUIT            = DssExecLib.getChangelogAddress("RWA015_A_OUTPUT_CONDUIT");
 
     // ---------- Trigger Spark Proxy Spell ----------
     // Spark Proxy: https://github.com/marsfoundation/sparklend-deployments/blob/bba4c57d54deb6a14490b897c12a949aa035a99b/script/output/1/primary-sce-latest.json#L2
@@ -167,7 +167,7 @@ contract DssSpellAction is DssAction {
         // Forum: https://forum.makerdao.com/t/proposed-housekeeping-items-upcoming-executive-spell-2024-04-18/24084
 
         // Call kiss on RWA015_A_OUTPUT_CONDUIT with address 0x6759610547a36E9597Ef452aa0B9cace91291a2f
-        RWA015_A_OUTPUT_CONDUIT.kiss(RWA015_A_CUSTODY_2);
+        RwaOutputConduitLike(RWA015_A_OUTPUT_CONDUIT).kiss(RWA015_A_CUSTODY_2);
 
         // ---------- Push USDP out of input conduit ----------
         // Forum: https://forum.makerdao.com/t/proposed-housekeeping-items-upcoming-executive-spell-2024-04-18/24084

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -28,6 +28,10 @@ interface JarLike {
     function void() external;
 }
 
+interface RwaOutputConduitLike {
+    function kiss(address) external;
+}
+
 interface ProxyLike {
     function exec(address target, bytes calldata args) external payable returns (bytes memory out);
 }
@@ -35,9 +39,9 @@ interface ProxyLike {
 contract DssSpellAction is DssAction {
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
-    // Hash: cast keccak -- "$(wget 'TODO' -q -O - 2>/dev/null)"
+    // Hash: cast keccak -- "$(wget 'https://raw.githubusercontent.com/makerdao/community/5af6ec64b9e0ff080ecd80a85d0a7d6bc3bd3406/governance/votes/Executive%20vote%20-%20April%2018%2C%202024.md' -q -O - 2>/dev/null)"
     string public constant override description =
-        "2024-04-18 MakerDAO Executive Spell | Hash: TODO";
+        "2024-04-18 MakerDAO Executive Spell | Hash: 0x71efd61f3800b237e562b1ad518d90b9a155fa6565c98c1cd8d383afcc69b146";
 
     // Set office hours according to the summary
     function officeHours() public pure override returns (bool) {
@@ -83,6 +87,10 @@ contract DssSpellAction is DssAction {
     address internal constant ROOT           = 0xC74392777443a11Dc26Ce8A3D934370514F38A91;
 
     address internal constant AAVE_V3_TREASURY = 0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c;
+
+    // ---------- Whitelist new address in the RWA015-A output conduit ----------
+    address internal constant RWA015_A_CUSTODY_2                 = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
+    RwaOutputConduitLike internal immutable RWA015_A_OUTPUT_CONDUIT = RwaOutputConduitLike(DssExecLib.getChangelogAddress("RWA015_A_OUTPUT_CONDUIT"));
 
     // ---------- Trigger Spark Proxy Spell ----------
     // Spark Proxy: https://github.com/marsfoundation/sparklend-deployments/blob/bba4c57d54deb6a14490b897c12a949aa035a99b/script/output/1/primary-sce-latest.json#L2
@@ -154,6 +162,12 @@ contract DssSpellAction is DssAction {
 
         // Transfer 238,339 DAI to 0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c
         DssExecLib.sendPaymentFromSurplusBuffer(AAVE_V3_TREASURY, 238_339);
+
+        // ---------- Whitelist new address in the RWA015-A output conduit ----------
+        // Forum: https://forum.makerdao.com/t/proposed-housekeeping-items-upcoming-executive-spell-2024-04-18/24084
+
+        // Call kiss on RWA015_A_OUTPUT_CONDUIT with address 0x6759610547a36E9597Ef452aa0B9cace91291a2f
+        RWA015_A_OUTPUT_CONDUIT.kiss(RWA015_A_CUSTODY_2);
 
         // ---------- Push USDP out of input conduit ----------
         // Forum: https://forum.makerdao.com/t/proposed-housekeeping-items-upcoming-executive-spell-2024-04-18/24084

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -63,8 +63,8 @@ contract DssSpellAction is DssAction {
     // ---------- Contract addresses ----------
     GemAbstract internal immutable MKR = GemAbstract(DssExecLib.mkr());
 
-    InputConduitJarLike internal immutable MCD_PSM_PAX_A_INPUT_CONDUIT_JAR = InputConduitJarLike(DssExecLib.getChangelogAddress("MCD_PSM_PAX_A_INPUT_CONDUIT_JAR"));
-    JarLike internal immutable MCD_PSM_PAX_A_JAR                           = JarLike(DssExecLib.getChangelogAddress("MCD_PSM_PAX_A_JAR"));
+    address internal immutable MCD_PSM_PAX_A_INPUT_CONDUIT_JAR = DssExecLib.getChangelogAddress("MCD_PSM_PAX_A_INPUT_CONDUIT_JAR");
+    address internal immutable MCD_PSM_PAX_A_JAR               = DssExecLib.getChangelogAddress("MCD_PSM_PAX_A_JAR");
 
     // ----------- Payment addresses -----------
     address internal constant BONAPUBLICA = 0x167c1a762B08D7e78dbF8f24e5C3f1Ab415021D3;
@@ -177,10 +177,10 @@ contract DssSpellAction is DssAction {
         DssExecLib.setIlkDebtCeiling("PSM-PAX-A", 100_000);
 
         // Call push() on MCD_PSM_PAX_A_INPUT_CONDUIT_JAR (use push(uint256 amt)) to push 84,211.27 USDP
-        MCD_PSM_PAX_A_INPUT_CONDUIT_JAR.push(84_211.27 ether); // Note: `ether` is only a keyword helper
+        InputConduitJarLike(MCD_PSM_PAX_A_INPUT_CONDUIT_JAR).push(84_211.27 ether); // Note: `ether` is only a keyword helper
 
         // Call void() on MCD_PSM_PAX_A_JAR
-        MCD_PSM_PAX_A_JAR.void();
+        JarLike(MCD_PSM_PAX_A_JAR).void();
 
         // Set PSM-PAX-A DC to 0 DAI
         DssExecLib.setIlkDebtCeiling("PSM-PAX-A", 0);

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -90,7 +90,8 @@ contract DssSpellAction is DssAction {
 
     // ---------- Whitelist new address in the RWA015-A output conduit ----------
     address internal constant RWA015_A_CUSTODY_2                 = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
-    address internal constant RWA015_A_OUTPUT_CONDUIT            = DssExecLib.getChangelogAddress("RWA015_A_OUTPUT_CONDUIT");
+    address internal immutable RWA015_A_OUTPUT_CONDUIT            = DssExecLib.getChangelogAddress("RWA015_A_OUTPUT_CONDUIT");
+
 
     // ---------- Trigger Spark Proxy Spell ----------
     // Spark Proxy: https://github.com/marsfoundation/sparklend-deployments/blob/bba4c57d54deb6a14490b897c12a949aa035a99b/script/output/1/primary-sce-latest.json#L2

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -19,32 +19,17 @@ pragma solidity 0.8.16;
 import "dss-exec-lib/DssExec.sol";
 import "dss-exec-lib/DssAction.sol";
 
-interface ProxyLike {
-    function exec(address target, bytes calldata args) external payable returns (bytes memory out);
-}
-
-interface PauseLike {
-    function setDelay(uint256) external;
-}
-
-interface LineMomLike {
-    function addIlk(bytes32 ilk) external;
-}
-
 contract DssSpellAction is DssAction {
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
-    // Hash: cast keccak -- "$(wget 'https://raw.githubusercontent.com/makerdao/community/c72ec9c04e022f1767b032025f1bfafe15490857/governance/votes/Executive%20Vote%20-%20April%204%2C%202024.md' -q -O - 2>/dev/null)"
+    // Hash: cast keccak -- "$(wget 'TODO' -q -O - 2>/dev/null)"
     string public constant override description =
-        "2024-04-04 MakerDAO Executive Spell | Hash: 0x6f8008ad08179d706d4ee801490b61ad5de8f4d4290dcbda9c028376d74ffca4";
+        "2024-04-18 MakerDAO Executive Spell | Hash: TODO";
 
     // Set office hours according to the summary
     function officeHours() public pure override returns (bool) {
         return false;
     }
-
-    // Note: by the previous convention it should be a comma-separated list of DAO resolutions IPFS hashes
-    string public constant dao_resolutions = "QmUarSLBgfvCK5Mco2QS8UraSqwxWtK5jKiEbxDYxE1C4A";
 
     // ---------- Rates ----------
     // Many of the settings that change weekly rely on the rate accumulator
@@ -58,74 +43,8 @@ contract DssSpellAction is DssAction {
     //
     // uint256 internal constant X_PCT_RATE = ;
 
-    // ---------- Math ----------
-    uint256 internal constant BILLION = 10 ** 9;
-
-    // ---------- Addesses ----------
-    address internal immutable MCD_PAUSE = DssExecLib.getChangelogAddress("MCD_PAUSE");
-    address internal immutable LINE_MOM  = DssExecLib.getChangelogAddress("LINE_MOM");
-
-    address internal constant SPARK_PROXY = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;
-    address internal constant SPARK_SPELL = 0x7748C5E6EEda836247F2AfCd5a7c0dA3c5de9Da2;
-
     function actions() public override {
-        // ---------- Increase the GSM Pause Delay ----------
-        // Forum: https://forum.makerdao.com/t/gsm-pause-delay-increase-proposal/23929
-        // Poll: https://vote.makerdao.com/polling/QmcLsYwj
 
-        // Increase the GSM Pause Delay by 14 hours, from 16 hours to 30 hours -----
-        PauseLike(MCD_PAUSE).setDelay(30 hours);
-
-        // ---------- Spark MetaMorpho Vault DDM ----------
-        // Forum: https://forum.makerdao.com/t/morpho-spark-dai-vault-update-1-april-2024/24006
-        // Forum: https://forum.makerdao.com/t/morpho-spark-dai-vault-update-1-april-2024/24006/8
-
-        // DDM DC-IAM Parameters: line: 1 billion DAI
-        DssExecLib.setIlkAutoLineDebtCeiling("DIRECT-SPARK-MORPHO-DAI", 1 * BILLION);
-
-        // ---------- Add the following ilks to LINE_MOM ----------
-        // Forum: https://forum.makerdao.com/t/gov12-1-2-bootstrapping-edit-proposal-gov10-2-3-1a-edit/24005
-        // Poll: https://vote.makerdao.com/polling/QmZsAM36
-
-        // ETH-A
-        LineMomLike(LINE_MOM).addIlk("ETH-A");
-
-        // ETH-B
-        LineMomLike(LINE_MOM).addIlk("ETH-B");
-
-        // ETH-C
-        LineMomLike(LINE_MOM).addIlk("ETH-C");
-
-        // WSTETH-A
-        LineMomLike(LINE_MOM).addIlk("WSTETH-A");
-
-        // WSTETH-B
-        LineMomLike(LINE_MOM).addIlk("WSTETH-B");
-
-        // WBTC-A
-        LineMomLike(LINE_MOM).addIlk("WBTC-A");
-
-        // WBTC-B
-        LineMomLike(LINE_MOM).addIlk("WBTC-B");
-
-        // WBTC-C
-        LineMomLike(LINE_MOM).addIlk("WBTC-C");
-
-        // ---------- Spark Proxy Spell ----------
-        // Forum: https://forum.makerdao.com/t/mar-21-2024-proposed-changes-to-sparklend-for-upcoming-spell/23918
-        // Forum: https://forum.makerdao.com/t/morpho-spark-dai-vault-update-1-april-2024/24006
-        // Poll: https://vote.makerdao.com/polling/QmdjqTvL
-        // Poll: https://vote.makerdao.com/polling/QmaEqEav
-        // Poll: https://vote.makerdao.com/polling/QmbCWUAP
-
-        // Trigger Spark Proxy Spell at 0x7748C5E6EEda836247F2AfCd5a7c0dA3c5de9Da2
-        ProxyLike(SPARK_PROXY).exec(SPARK_SPELL, abi.encodeWithSignature("execute()"));
-
-        // ---------- Approve TACO Resolution ----------
-        // Forum: https://forum.makerdao.com/t/bt-project-ethena-risk-legal-assessment/23978
-
-        // Approve IPFS Resolutions: QmUarSLBgfvCK5Mco2QS8UraSqwxWtK5jKiEbxDYxE1C4A
-        // Note: see `dao_resolutions` variable declared above
     }
 }
 

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -101,6 +101,7 @@ contract DssSpellAction is DssAction {
     function actions() public override {
         // ---------- AD Compensation ----------
         // Forum: https://forum.makerdao.com/t/march-2024-aligned-delegate-compensation/24088
+        // MIP: https://mips.makerdao.com/mips/details/MIP101#2-6-3-aligned-delegate-income-and-participation-requirements
 
         // BONAPUBLICA - 41.67 MKR - 0x167c1a762B08D7e78dbF8f24e5C3f1Ab415021D3
         MKR.transfer(BONAPUBLICA, 41.67 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
@@ -128,6 +129,7 @@ contract DssSpellAction is DssAction {
 
         // ---------- AVC Member Compensation ----------
         // Forum: https://forum.makerdao.com/t/avc-member-participation-rewards-q1-2024/24083
+        // MIP: https://mips.makerdao.com/mips/details/MIP101#2-5-10-avc-member-participation-rewards
 
         // IamMeeoh - 20.85 MKR - 0x47f7A5d8D27f259582097E1eE59a07a816982AE9
         MKR.transfer(IAMMEEOH, 20.85 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -88,10 +88,6 @@ contract DssSpellAction is DssAction {
 
     address internal constant AAVE_V3_TREASURY = 0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c;
 
-    // ---------- Whitelist new address in the RWA015-A output conduit ----------
-    address internal constant RWA015_A_CUSTODY_2                 = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
-    RwaOutputConduitLike internal immutable RWA015_A_OUTPUT_CONDUIT = RwaOutputConduitLike(DssExecLib.getChangelogAddress("RWA015_A_OUTPUT_CONDUIT"));
-
     // ---------- Trigger Spark Proxy Spell ----------
     // Spark Proxy: https://github.com/marsfoundation/sparklend-deployments/blob/bba4c57d54deb6a14490b897c12a949aa035a99b/script/output/1/primary-sce-latest.json#L2
     address internal constant SPARK_PROXY = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;
@@ -162,12 +158,6 @@ contract DssSpellAction is DssAction {
 
         // Transfer 238,339 DAI to 0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c
         DssExecLib.sendPaymentFromSurplusBuffer(AAVE_V3_TREASURY, 238_339);
-
-        // ---------- Whitelist new address in the RWA015-A output conduit ----------
-        // Forum: https://forum.makerdao.com/t/proposed-housekeeping-items-upcoming-executive-spell-2024-04-18/24084
-
-        // Call kiss on RWA015_A_OUTPUT_CONDUIT with address 0x6759610547a36E9597Ef452aa0B9cace91291a2f
-        RWA015_A_OUTPUT_CONDUIT.kiss(RWA015_A_CUSTODY_2);
 
         // ---------- Push USDP out of input conduit ----------
         // Forum: https://forum.makerdao.com/t/proposed-housekeeping-items-upcoming-executive-spell-2024-04-18/24084

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -39,9 +39,9 @@ interface ProxyLike {
 contract DssSpellAction is DssAction {
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
-    // Hash: cast keccak -- "$(wget 'https://raw.githubusercontent.com/makerdao/community/5af6ec64b9e0ff080ecd80a85d0a7d6bc3bd3406/governance/votes/Executive%20vote%20-%20April%2018%2C%202024.md' -q -O - 2>/dev/null)"
+    // Hash: cast keccak -- "$(wget 'https://raw.githubusercontent.com/makerdao/community/17bde44a63e34418b201a0a3fdbe4a53c7388407/governance/votes/Executive%20vote%20-%20April%2018%2C%202024.md' -q -O - 2>/dev/null)"
     string public constant override description =
-        "2024-04-18 MakerDAO Executive Spell | Hash: 0x71efd61f3800b237e562b1ad518d90b9a155fa6565c98c1cd8d383afcc69b146";
+        "2024-04-18 MakerDAO Executive Spell | Hash: 0x02a4122befd8f49787e5c08ef21fa4e205e234b29c54d9e47586ccc2f9eaaaab";
 
     // Set office hours according to the summary
     function officeHours() public pure override returns (bool) {

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -186,6 +186,15 @@ contract DssSpellAction is DssAction {
 
         // ---------- Spark Proxy Spell ----------
         // Forum: https://forum.makerdao.com/t/apr-4-2024-proposed-changes-to-sparklend-for-upcoming-spell/24033
+        // Poll: https://vote.makerdao.com/polling/QmZND8WW
+        // Poll: https://vote.makerdao.com/polling/QmcRdMyA
+        // Poll: https://vote.makerdao.com/polling/QmSh8gyC
+        // Poll: https://vote.makerdao.com/polling/QmfGV2vt
+        // Poll: https://vote.makerdao.com/polling/QmSYZSCQ
+        // Poll: https://vote.makerdao.com/polling/QmUhT32b
+        // Poll: https://vote.makerdao.com/polling/QmVsKsGa
+        // Forum: https://forum.makerdao.com/t/sparklend-external-security-access-multisig-for-freezer-mom/24070
+        // Poll: https://vote.makerdao.com/polling/QmVXriiT
 
         // Trigger Spark Proxy Spell at 0x3d1DD14Fa08163E7f64b0abf0F514f6276f50882
         ProxyLike(SPARK_PROXY).exec(SPARK_SPELL, abi.encodeWithSignature("execute()"));

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -39,6 +39,7 @@ interface ProxyLike {
 contract DssSpellAction is DssAction {
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
+    // TODO: update the hash after update the content in exec doc
     // Hash: cast keccak -- "$(wget 'https://raw.githubusercontent.com/makerdao/community/17bde44a63e34418b201a0a3fdbe4a53c7388407/governance/votes/Executive%20vote%20-%20April%2018%2C%202024.md' -q -O - 2>/dev/null)"
     string public constant override description =
         "2024-04-18 MakerDAO Executive Spell | Hash: 0x02a4122befd8f49787e5c08ef21fa4e205e234b29c54d9e47586ccc2f9eaaaab";
@@ -59,6 +60,14 @@ contract DssSpellAction is DssAction {
     //    https://ipfs.io/ipfs/QmVp4mhhbwWGTfbh2BzwQB9eiBrQBKiqcPRZCaAxNUaar6
     //
     // uint256 internal constant X_PCT_RATE = ;
+    uint256 internal constant ELEVEN_PCT_RATE               = 1000000003309234382829738808;
+    uint256 internal constant ELEVEN_PT_TWO_FIVE_PCT_RATE   = 1000000003380572527855758393;
+    uint256 internal constant ELEVEN_PT_SEVEN_FIVE_PCT_RATE = 1000000003522769143241571114;
+    uint256 internal constant TWELVE_PCT_RATE               = 1000000003593629043335673582;
+    uint256 internal constant TWELVE_PT_TWO_FIVE_PCT_RATE   = 1000000003664330950215446102;
+    uint256 internal constant TWELVE_PT_FIVE_PCT_RATE       = 1000000003734875566854894261;
+    uint256 internal constant TWELVE_PT_SEVEN_FIVE_PCT_RATE = 1000000003805263591546724039;
+    uint256 internal constant THIRTEEN_PT_TWO_FIVE_PCT_RATE = 1000000003945572635100236468;
 
     // ---------- Contract addresses ----------
     GemAbstract internal immutable MKR = GemAbstract(DssExecLib.mkr());
@@ -184,6 +193,30 @@ contract DssSpellAction is DssAction {
 
         // Set PSM-PAX-A DC to 0 DAI
         DssExecLib.setIlkDebtCeiling("PSM-PAX-A", 0);
+
+        // ---------- TODO: Stability Fee Changes ----------
+        // Forum: TODO
+
+        DssExecLib.setIlkStabilityFee("ETH-A", ELEVEN_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        DssExecLib.setIlkStabilityFee("ETH-B", ELEVEN_PT_SEVEN_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        DssExecLib.setIlkStabilityFee("ETH-C", ELEVEN_PCT_RATE, /* doDrip = */ true);
+
+        DssExecLib.setIlkStabilityFee("WSTETH-A", TWELVE_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        DssExecLib.setIlkStabilityFee("WSTETH-B", TWELVE_PCT_RATE, /* doDrip = */ true);
+
+        DssExecLib.setIlkStabilityFee("WBTC-A", TWELVE_PT_SEVEN_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        DssExecLib.setIlkStabilityFee("WBTC-B", THIRTEEN_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        DssExecLib.setIlkStabilityFee("WBTC-C", TWELVE_PT_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // ---------- TODO: DSR Change ----------
+        // Forum: TODO
+
+        DssExecLib.setDSR(ELEVEN_PCT_RATE, /* doDrip = */ true);
 
         // ---------- Spark Proxy Spell ----------
         // Forum: https://forum.makerdao.com/t/apr-4-2024-proposed-changes-to-sparklend-for-upcoming-spell/24033

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -95,8 +95,7 @@ contract DssSpellAction is DssAction {
     // ---------- Trigger Spark Proxy Spell ----------
     // Spark Proxy: https://github.com/marsfoundation/sparklend-deployments/blob/bba4c57d54deb6a14490b897c12a949aa035a99b/script/output/1/primary-sce-latest.json#L2
     address internal constant SPARK_PROXY = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;
-    // TODO: Update with the correct spell address
-    address internal constant SPARK_SPELL = address(0);
+    address internal constant SPARK_SPELL = 0x3d1DD14Fa08163E7f64b0abf0F514f6276f50882;
 
     function actions() public override {
         // ---------- AD Compensation ----------
@@ -188,7 +187,7 @@ contract DssSpellAction is DssAction {
         // ---------- Spark Proxy Spell ----------
         // Forum: https://forum.makerdao.com/t/apr-4-2024-proposed-changes-to-sparklend-for-upcoming-spell/24033
 
-        // Trigger Spark Proxy Spell at TBD
+        // Trigger Spark Proxy Spell at 0x3d1DD14Fa08163E7f64b0abf0F514f6276f50882
         ProxyLike(SPARK_PROXY).exec(SPARK_SPELL, abi.encodeWithSignature("execute()"));
     }
 }

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -18,6 +18,7 @@ pragma solidity 0.8.16;
 
 import "dss-exec-lib/DssExec.sol";
 import "dss-exec-lib/DssAction.sol";
+import { GemAbstract } from "dss-interfaces/ERC/GemAbstract.sol";
 
 interface InputConduitJarLike {
     function push(uint256) external;
@@ -25,6 +26,10 @@ interface InputConduitJarLike {
 
 interface JarLike {
     function void() external;
+}
+
+interface RwaOutputConduitLike {
+    function kiss(address) external;
 }
 
 interface ProxyLike {
@@ -55,31 +60,101 @@ contract DssSpellAction is DssAction {
     //
     // uint256 internal constant X_PCT_RATE = ;
 
-    // ----------- Payment Addresses -----------
+    // ---------- Contract addresses ----------
+    GemAbstract internal immutable MKR = GemAbstract(DssExecLib.mkr());
 
-    // AAVE
-    address constant internal AAVE_V3_TREASURY = 0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c;
-
-    // ---------- Contracts ----------
     InputConduitJarLike internal immutable MCD_PSM_PAX_A_INPUT_CONDUIT_JAR = InputConduitJarLike(DssExecLib.getChangelogAddress("MCD_PSM_PAX_A_INPUT_CONDUIT_JAR"));
     JarLike internal immutable MCD_PSM_PAX_A_JAR                           = JarLike(DssExecLib.getChangelogAddress("MCD_PSM_PAX_A_JAR"));
 
+    // ----------- Payment addresses -----------
+    address internal constant BONAPUBLICA = 0x167c1a762B08D7e78dbF8f24e5C3f1Ab415021D3;
+    address internal constant CLOAKY      = 0x869b6d5d8FA7f4FFdaCA4D23FFE0735c5eD1F818;
+    address internal constant TRUENAME    = 0x612F7924c367575a0Edf21333D96b15F1B345A5d;
+    address internal constant BLUE        = 0xb6C09680D822F162449cdFB8248a7D3FC26Ec9Bf;
+    address internal constant VIGILANT    = 0x2474937cB55500601BCCE9f4cb0A0A72Dc226F61;
+    address internal constant PIPKIN      = 0x0E661eFE390aE39f90a58b04CF891044e56DEDB7;
+    address internal constant JAG         = 0x58D1ec57E4294E4fe650D1CB12b96AE34349556f;
+    address internal constant UPMAKER     = 0xbB819DF169670DC71A16F58F55956FE642cc6BcD;
+
+    address internal constant IAMMEEOH       = 0x47f7A5d8D27f259582097E1eE59a07a816982AE9;
+    address internal constant DAI_VINCI      = 0x9ee47F0f82F1A6F45C4E1D25Ce95C321D8C8356a;
+    address internal constant OPENSKY_2      = 0xf44f97f4113759E0a57756bE49C0655d490Cf19F;
+    address internal constant ACREDAOS       = 0xBF9226345F601150F64Ea4fEaAE7E40530763cbd;
+    address internal constant RES            = 0x8c5c8d76372954922400e4654AF7694e158AB784;
+    address internal constant HARMONY_2      = 0xE20A2e231215e9b7Aa308463F1A7490b2ECE55D3;
+    address internal constant LIBERTAS       = 0xE1eBfFa01883EF2b4A9f59b587fFf1a5B44dbb2f;
+    address internal constant SEEDLATAMETH_2 = 0xd43b89621fFd48A8A51704f85fd0C87CbC0EB299;
+    address internal constant ROOT           = 0xC74392777443a11Dc26Ce8A3D934370514F38A91;
+
+    address internal constant AAVE_V3_TREASURY = 0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c;
+
+    // ---------- Whitelist new address in the RWA015-A output conduit ----------
+    address internal constant RWA015_A_CUSTODY_TACO                 = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
+    RwaOutputConduitLike internal immutable RWA015_A_OUTPUT_CONDUIT = RwaOutputConduitLike(DssExecLib.getChangelogAddress("RWA015_A_OUTPUT_CONDUIT"));
+
     // ---------- Trigger Spark Proxy Spell ----------
-    // Spark Proxy: https://github.com/marsfoundation/sparklend/blob/d42587ba36523dcff24a4c827dc29ab71cd0808b/script/output/1/primary-sce-latest.json#L2
+    // Spark Proxy: https://github.com/marsfoundation/sparklend-deployments/blob/bba4c57d54deb6a14490b897c12a949aa035a99b/script/output/1/primary-sce-latest.json#L2
     address internal constant SPARK_PROXY = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;
     // TODO: Update with the correct spell address
     address internal constant SPARK_SPELL = address(0);
 
     function actions() public override {
         // ---------- AD Compensation ----------
-        // Forum: TODO
+        // Forum: https://forum.makerdao.com/t/march-2024-aligned-delegate-compensation/24088
 
-        // TBD
+        // BONAPUBLICA - 41.67 MKR - 0x167c1a762B08D7e78dbF8f24e5C3f1Ab415021D3
+        MKR.transfer(BONAPUBLICA, 41.67 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // Cloaky - 41.67 MKR - 0x869b6d5d8FA7f4FFdaCA4D23FFE0735c5eD1F818
+        MKR.transfer(CLOAKY, 41.67 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // TRUE NAME - 41.67 MKR - 0x612F7924c367575a0Edf21333D96b15F1B345A5d
+        MKR.transfer(TRUENAME, 41.67 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // BLUE - 39.75 MKR - 0xb6C09680D822F162449cdFB8248a7D3FC26Ec9Bf
+        MKR.transfer(BLUE, 39.75 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // vigilant - 13.89 MKR - 0x2474937cB55500601BCCE9f4cb0A0A72Dc226F61
+        MKR.transfer(VIGILANT, 13.89 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // Pipkin - 13.89 MKR - 0x0E661eFE390aE39f90a58b04CF891044e56DEDB7
+        MKR.transfer(PIPKIN, 13.89 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // JAG - 13.89 MKR - 0x58D1ec57E4294E4fe650D1CB12b96AE34349556f
+        MKR.transfer(JAG, 13.89 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // UPMaker - 12.93 MKR - 0xbB819DF169670DC71A16F58F55956FE642cc6BcD
+        MKR.transfer(UPMAKER, 12.93 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
 
         // ---------- AVC Member Compensation ----------
-        // Forum: TODO
+        // Forum: https://forum.makerdao.com/t/avc-member-participation-rewards-q1-2024/24083
 
-        // TBD
+        // IamMeeoh - 20.85 MKR - 0x47f7A5d8D27f259582097E1eE59a07a816982AE9
+        MKR.transfer(IAMMEEOH, 20.85 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // DAI-Vinci - 20.85 MKR - 0x9ee47F0f82F1A6F45C4E1D25Ce95C321D8C8356a
+        MKR.transfer(DAI_VINCI, 20.85 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // opensky - 20.85 MKR - 0xf44f97f4113759E0a57756bE49C0655d490Cf19F
+        MKR.transfer(OPENSKY_2, 20.85 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // ACRE DAOs - 20.85 MKR - 0xBF9226345F601150F64Ea4fEaAE7E40530763cbd
+        MKR.transfer(ACREDAOS, 20.85 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // Res - 20.85 MKR - 0x8c5c8d76372954922400e4654AF7694e158AB784
+        MKR.transfer(RES, 20.85 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // Harmony - 20.85 MKR - 0xE20A2e231215e9b7Aa308463F1A7490b2ECE55D3
+        MKR.transfer(HARMONY_2, 20.85 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // Libertas - 20.85 MKR - 0xE1eBfFa01883EF2b4A9f59b587fFf1a5B44dbb2f
+        MKR.transfer(LIBERTAS, 20.85 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // seedlatam.eth - 20.85 MKR - 0xd43b89621fFd48A8A51704f85fd0C87CbC0EB299
+        MKR.transfer(SEEDLATAMETH_2, 20.85 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
+
+        // 0xRoot - 8.34 MKR - 0xC74392777443a11Dc26Ce8A3D934370514F38A91
+        MKR.transfer(ROOT, 8.34 ether); // NOTE: 'ether' is a keyword helper, only MKR is transferred here
 
         // ---------- Aave Revenue Share ----------
         // Forum: https://forum.makerdao.com/t/spark-aave-revenue-share-calculation-payment-3-q1-2024/24014
@@ -88,12 +163,13 @@ contract DssSpellAction is DssAction {
         DssExecLib.sendPaymentFromSurplusBuffer(AAVE_V3_TREASURY, 238_339);
 
         // ---------- Whitelist new address in the RWA015-A output conduit ----------
-        // Forum: TODO
+        // Forum: https://forum.makerdao.com/t/proposed-housekeeping-items-upcoming-executive-spell-2024-04-18/24084
 
-        // TBD
+        // Call kiss on RWA015_A_OUTPUT_CONDUIT with address 0x6759610547a36E9597Ef452aa0B9cace91291a2f
+        RWA015_A_OUTPUT_CONDUIT.kiss(RWA015_A_CUSTODY_TACO);
 
         // ---------- Push USDP out of input conduit ----------
-        // Forum: TODO
+        // Forum: https://forum.makerdao.com/t/proposed-housekeeping-items-upcoming-executive-spell-2024-04-18/24084
 
         // Raise PSM-PAX-A DC to 100,000 DAI
         DssExecLib.setIlkDebtCeiling("PSM-PAX-A", 100_000);
@@ -108,7 +184,7 @@ contract DssSpellAction is DssAction {
         DssExecLib.setIlkDebtCeiling("PSM-PAX-A", 0);
 
         // ---------- Spark Proxy Spell ----------
-        // Forum: TODO
+        // Forum: https://forum.makerdao.com/t/apr-4-2024-proposed-changes-to-sparklend-for-upcoming-spell/24033
 
         // Trigger Spark Proxy Spell at TBD
         ProxyLike(SPARK_PROXY).exec(SPARK_SPELL, abi.encodeWithSignature("execute()"));

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -39,10 +39,9 @@ interface ProxyLike {
 contract DssSpellAction is DssAction {
     // Provides a descriptive tag for bot consumption
     // This should be modified weekly to provide a summary of the actions
-    // TODO: update the hash after update the content in exec doc
-    // Hash: cast keccak -- "$(wget 'https://raw.githubusercontent.com/makerdao/community/17bde44a63e34418b201a0a3fdbe4a53c7388407/governance/votes/Executive%20vote%20-%20April%2018%2C%202024.md' -q -O - 2>/dev/null)"
+    // Hash: cast keccak -- "$(wget 'https://raw.githubusercontent.com/makerdao/community/66aa0bcc2522ef68cd07404a220f3d0ceed66ff6/governance/votes/Executive%20vote%20-%20April%2022%2C%202024.md' -q -O - 2>/dev/null)"
     string public constant override description =
-        "2024-04-18 MakerDAO Executive Spell | Hash: 0x02a4122befd8f49787e5c08ef21fa4e205e234b29c54d9e47586ccc2f9eaaaab";
+        "2024-04-18 MakerDAO Executive Spell | Hash: 0x795156c619f653246521bff408f49666bc1a13c626ff197e84973974782d60a7";
 
     // Set office hours according to the summary
     function officeHours() public pure override returns (bool) {
@@ -59,15 +58,15 @@ contract DssSpellAction is DssAction {
     // A table of rates can be found at
     //    https://ipfs.io/ipfs/QmVp4mhhbwWGTfbh2BzwQB9eiBrQBKiqcPRZCaAxNUaar6
     //
-    // uint256 internal constant X_PCT_RATE = ;
+    // uint256 internal constant X_PCT_1000000003022265980097387650RATE = ;
+    uint256 internal constant TEN_PCT_RATE                  = 1000000003022265980097387650;
+    uint256 internal constant TEN_PT_TWO_FIVE_PCT_RATE      = 1000000003094251918120023627;
+    uint256 internal constant TEN_PT_SEVEN_FIVE_PCT_RATE    = 1000000003237735385034516037;
     uint256 internal constant ELEVEN_PCT_RATE               = 1000000003309234382829738808;
     uint256 internal constant ELEVEN_PT_TWO_FIVE_PCT_RATE   = 1000000003380572527855758393;
+    uint256 internal constant ELEVEN_PT_FIVE_PCT_RATE       = 1000000003451750542235895695;
     uint256 internal constant ELEVEN_PT_SEVEN_FIVE_PCT_RATE = 1000000003522769143241571114;
-    uint256 internal constant TWELVE_PCT_RATE               = 1000000003593629043335673582;
     uint256 internal constant TWELVE_PT_TWO_FIVE_PCT_RATE   = 1000000003664330950215446102;
-    uint256 internal constant TWELVE_PT_FIVE_PCT_RATE       = 1000000003734875566854894261;
-    uint256 internal constant TWELVE_PT_SEVEN_FIVE_PCT_RATE = 1000000003805263591546724039;
-    uint256 internal constant THIRTEEN_PT_TWO_FIVE_PCT_RATE = 1000000003945572635100236468;
 
     // ---------- Contract addresses ----------
     GemAbstract internal immutable MKR = GemAbstract(DssExecLib.mkr());
@@ -105,9 +104,42 @@ contract DssSpellAction is DssAction {
     // ---------- Trigger Spark Proxy Spell ----------
     // Spark Proxy: https://github.com/marsfoundation/sparklend-deployments/blob/bba4c57d54deb6a14490b897c12a949aa035a99b/script/output/1/primary-sce-latest.json#L2
     address internal constant SPARK_PROXY = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;
-    address internal constant SPARK_SPELL = 0x3d1DD14Fa08163E7f64b0abf0F514f6276f50882;
+    address internal constant SPARK_SPELL = 0x151D5fA7B3eD50098fFfDd61DB29cB928aE04C0e;
 
     function actions() public override {
+        // ---------- Stability Fee Updates ----------
+        // Forum: http://forum.makerdao.com/t/stability-scope-parameter-changes-12-under-sta-article-3-3/24132
+
+        // ETH-A: Decrease the Stability Fee by 3 percentage points from 13.25% to 10.25%
+        DssExecLib.setIlkStabilityFee("ETH-A", TEN_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // ETH-B: Decrease the Stability Fee by 3 percentage points from 13.75% to 10.75%
+        DssExecLib.setIlkStabilityFee("ETH-B", TEN_PT_SEVEN_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // ETH-C: Decrease the Stability Fee by 3 percentage points from 13.00% to 10.00%
+        DssExecLib.setIlkStabilityFee("ETH-C", TEN_PCT_RATE, /* doDrip = */ true);
+
+        // WSTETH-A: Decrease the Stability Fee by 3 percentage points from 14.25% to 11.25%
+        DssExecLib.setIlkStabilityFee("WSTETH-A", ELEVEN_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // WSTETH-B: Decrease the Stability Fee by 3 percentage points from 14.00% to 11.00%
+        DssExecLib.setIlkStabilityFee("WSTETH-B", ELEVEN_PCT_RATE, /* doDrip = */ true);
+
+        // WBTC-A: Decrease the Stability Fee by 3 percentage points from 14.75% to 11.75%
+        DssExecLib.setIlkStabilityFee("WBTC-A", ELEVEN_PT_SEVEN_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // WBTC-B: Decrease the Stability Fee by 3 percentage points from 15.25% to 12.25%
+        DssExecLib.setIlkStabilityFee("WBTC-B", TWELVE_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // WBTC-C: Decrease the Stability Fee by 3 percentage points from 14.50% to 11.50%
+        DssExecLib.setIlkStabilityFee("WBTC-C", ELEVEN_PT_FIVE_PCT_RATE, /* doDrip = */ true);
+
+        // ---------- DSR Change ----------
+        // Forum: http://forum.makerdao.com/t/stability-scope-parameter-changes-12-under-sta-article-3-3/24132
+
+        // DSR: Decrease the Dai Savings Rate by 3 percentage points from 13.00% to 10.00%
+        DssExecLib.setDSR(TEN_PCT_RATE, /* doDrip = */ true);
+
         // ---------- AD Compensation ----------
         // Forum: https://forum.makerdao.com/t/march-2024-aligned-delegate-compensation/24088
         // MIP: https://mips.makerdao.com/mips/details/MIP101#2-6-3-aligned-delegate-income-and-participation-requirements
@@ -194,30 +226,6 @@ contract DssSpellAction is DssAction {
         // Set PSM-PAX-A DC to 0 DAI
         DssExecLib.setIlkDebtCeiling("PSM-PAX-A", 0);
 
-        // ---------- TODO: Stability Fee Changes ----------
-        // Forum: TODO
-
-        DssExecLib.setIlkStabilityFee("ETH-A", ELEVEN_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
-
-        DssExecLib.setIlkStabilityFee("ETH-B", ELEVEN_PT_SEVEN_FIVE_PCT_RATE, /* doDrip = */ true);
-
-        DssExecLib.setIlkStabilityFee("ETH-C", ELEVEN_PCT_RATE, /* doDrip = */ true);
-
-        DssExecLib.setIlkStabilityFee("WSTETH-A", TWELVE_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
-
-        DssExecLib.setIlkStabilityFee("WSTETH-B", TWELVE_PCT_RATE, /* doDrip = */ true);
-
-        DssExecLib.setIlkStabilityFee("WBTC-A", TWELVE_PT_SEVEN_FIVE_PCT_RATE, /* doDrip = */ true);
-
-        DssExecLib.setIlkStabilityFee("WBTC-B", THIRTEEN_PT_TWO_FIVE_PCT_RATE, /* doDrip = */ true);
-
-        DssExecLib.setIlkStabilityFee("WBTC-C", TWELVE_PT_FIVE_PCT_RATE, /* doDrip = */ true);
-
-        // ---------- TODO: DSR Change ----------
-        // Forum: TODO
-
-        DssExecLib.setDSR(ELEVEN_PCT_RATE, /* doDrip = */ true);
-
         // ---------- Spark Proxy Spell ----------
         // Forum: https://forum.makerdao.com/t/apr-4-2024-proposed-changes-to-sparklend-for-upcoming-spell/24033
         // Poll: https://vote.makerdao.com/polling/QmZND8WW
@@ -229,8 +237,9 @@ contract DssSpellAction is DssAction {
         // Poll: https://vote.makerdao.com/polling/QmVsKsGa
         // Forum: https://forum.makerdao.com/t/sparklend-external-security-access-multisig-for-freezer-mom/24070
         // Poll: https://vote.makerdao.com/polling/QmVXriiT
+        // Forum: http://forum.makerdao.com/t/stability-scope-parameter-changes-12-under-sta-article-3-3/24132
 
-        // Trigger Spark Proxy Spell at 0x3d1DD14Fa08163E7f64b0abf0F514f6276f50882
+        // Trigger Spark Proxy Spell at 0x151D5fA7B3eD50098fFfDd61DB29cB928aE04C0e
         ProxyLike(SPARK_PROXY).exec(SPARK_SPELL, abi.encodeWithSignature("execute()"));
     }
 }

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -89,7 +89,7 @@ contract DssSpellAction is DssAction {
     address internal constant AAVE_V3_TREASURY = 0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c;
 
     // ---------- Whitelist new address in the RWA015-A output conduit ----------
-    address internal constant RWA015_A_CUSTODY_TACO                 = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
+    address internal constant RWA015_A_CUSTODY_2                 = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
     RwaOutputConduitLike internal immutable RWA015_A_OUTPUT_CONDUIT = RwaOutputConduitLike(DssExecLib.getChangelogAddress("RWA015_A_OUTPUT_CONDUIT"));
 
     // ---------- Trigger Spark Proxy Spell ----------
@@ -168,7 +168,7 @@ contract DssSpellAction is DssAction {
         // Forum: https://forum.makerdao.com/t/proposed-housekeeping-items-upcoming-executive-spell-2024-04-18/24084
 
         // Call kiss on RWA015_A_OUTPUT_CONDUIT with address 0x6759610547a36E9597Ef452aa0B9cace91291a2f
-        RWA015_A_OUTPUT_CONDUIT.kiss(RWA015_A_CUSTODY_TACO);
+        RWA015_A_OUTPUT_CONDUIT.kiss(RWA015_A_CUSTODY_2);
 
         // ---------- Push USDP out of input conduit ----------
         // Forum: https://forum.makerdao.com/t/proposed-housekeeping-items-upcoming-executive-spell-2024-04-18/24084
@@ -182,7 +182,7 @@ contract DssSpellAction is DssAction {
         // Call void() on MCD_PSM_PAX_A_JAR
         MCD_PSM_PAX_A_JAR.void();
 
-        // Set PSM-PAX-A DC to 0 DAI to 0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c
+        // Set PSM-PAX-A DC to 0 DAI
         DssExecLib.setIlkDebtCeiling("PSM-PAX-A", 0);
 
         // ---------- Spark Proxy Spell ----------

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -44,7 +44,41 @@ contract DssSpellAction is DssAction {
     // uint256 internal constant X_PCT_RATE = ;
 
     function actions() public override {
+        // ---------- AD Compensation ----------
+        // Forum: TODO
 
+        // TBD
+
+        // ---------- AVC Member Compensation ----------
+        // Forum: TODO
+
+        // TBD
+
+        // ---------- Aave Revenue Share ----------
+        // Forum: https://forum.makerdao.com/t/spark-aave-revenue-share-calculation-payment-3-q1-2024/24014
+
+        // Transfer 238,339 DAI to 0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c
+
+        // ---------- Whitelist new address in the RWA015-A output conduit ----------
+        // Forum: TODO
+
+        // TBD
+
+        // ---------- Push USDP out of input conduit ----------
+        // Forum: TODO
+
+        // Raise PSM-PAX-A DC to 100,000 DAI
+
+        // Call push() on MCD_PSM_PAX_A_INPUT_CONDUIT_JAR (use push(uint256 amt)) to push 84,210.26 USDP
+
+        // Call void() on MCD_PSM_PAX_A_JAR
+
+        // Set PSM-PAX-A DC to 0 DAI to 0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c
+
+        // ---------- Spark Proxy Spell ----------
+        // Forum: TODO
+
+        // Trigger Spark Proxy Spell at TBD
     }
 }
 

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -90,7 +90,7 @@ contract DssSpellAction is DssAction {
 
     // ---------- Whitelist new address in the RWA015-A output conduit ----------
     address internal constant RWA015_A_CUSTODY_2                 = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
-    address internal immutable RWA015_A_OUTPUT_CONDUIT            = DssExecLib.getChangelogAddress("RWA015_A_OUTPUT_CONDUIT");
+    address internal immutable RWA015_A_OUTPUT_CONDUIT           = DssExecLib.getChangelogAddress("RWA015_A_OUTPUT_CONDUIT");
 
 
     // ---------- Trigger Spark Proxy Spell ----------

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -28,10 +28,6 @@ interface JarLike {
     function void() external;
 }
 
-interface RwaOutputConduitLike {
-    function kiss(address) external;
-}
-
 interface ProxyLike {
     function exec(address target, bytes calldata args) external payable returns (bytes memory out);
 }

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -859,8 +859,7 @@ contract DssSpellTest is DssSpellTestBase {
 
     function testSparkSpellIsExecuted() public { // add the `skipped` modifier to skip
         address SPARK_PROXY = addr.addr('SPARK_PROXY');
-        // TODO: Update with the correct spell address
-        address SPARK_SPELL = address(0);
+        address SPARK_SPELL =0x3d1DD14Fa08163E7f64b0abf0F514f6276f50882;
 
         vm.expectCall(
             SPARK_PROXY,

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -44,16 +44,6 @@ interface SpellActionLike {
     function dao_resolutions() external view returns (string memory);
 }
 
-interface RwaSwapOutputConduitLike {
-    function bud(address) external view returns (uint256);
-    function mate(address) external;
-    function hope(address) external;
-    function hook(address) external;
-    function pick(address) external;
-    function push(uint256) external;
-    function quit() external;
-}
-
 contract DssSpellTest is DssSpellTestBase {
     string         config;
     RootDomain     rootDomain;

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -609,7 +609,7 @@ contract DssSpellTest is DssSpellTestBase {
             Payee(wallets.addr("BLUE"),           39.75 ether), // Note: ether is a keyword helper, only MKR is transferred here
             Payee(wallets.addr("VIGILANT"),       13.89 ether), // Note: ether is a keyword helper, only MKR is transferred here
             Payee(wallets.addr("PIPKIN"),         13.89 ether), // Note: ether is a keyword helper, only MKR is transferred here
-            Payee(wallets.addr("JAG"),            13.89 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("JAG"),            9.08 ether), // Note: ether is a keyword helper, only MKR is transferred here
             Payee(wallets.addr("UPMAKER"),        12.93 ether), // Note: ether is a keyword helper, only MKR is transferred here
             Payee(wallets.addr("IAMMEEOH"),       20.85 ether), // Note: ether is a keyword helper, only MKR is transferred here
             Payee(wallets.addr("DAI_VINCI"),      20.85 ether), // Note: ether is a keyword helper, only MKR is transferred here
@@ -622,7 +622,7 @@ contract DssSpellTest is DssSpellTestBase {
             Payee(wallets.addr("ROOT"),           8.34 ether)  // Note: ether is a keyword helper, only MKR is transferred here
         ];
         // Fill the value below with the value from exec doc
-        uint256 expectedSumPayments = 394.5 ether; // Note: ether is a keyword helper, only MKR is transferred here
+        uint256 expectedSumPayments = 389.69 ether; // Note: ether is a keyword helper, only MKR is transferred here
 
         // Calculate and save previous balances
         uint256 totalAmountToTransfer = 0; // Increment in the loop below
@@ -879,20 +879,20 @@ contract DssSpellTest is DssSpellTestBase {
     // SPELL-SPECIFIC TESTS GO BELOW
 
     function testRWA015NewBud() public {
-        address NEW_BUD = addr.addr("RWA015_A_CUSTODY_2");
+        address RWA015_A_CUSTODY_2 = addr.addr("RWA015_A_CUSTODY_2");
         RwaSwapOutputConduitLike rwa015AOutputConduit = RwaSwapOutputConduitLike(addr.addr("RWA015_A_OUTPUT_CONDUIT"));
 
-        assertEq(rwa015AOutputConduit.bud(NEW_BUD), 0, 'TestError/already-bud');
+        assertEq(rwa015AOutputConduit.bud(RWA015_A_CUSTODY_2), 0, 'TestError/already-bud');
 
         _vote(address(spell));
         _scheduleWaitAndCast(address(spell));
         assertTrue(spell.done());
 
-        assertEq(rwa015AOutputConduit.bud(NEW_BUD), 1, 'TestError/not-bud-after-cast');
+        assertEq(rwa015AOutputConduit.bud(RWA015_A_CUSTODY_2), 1, 'TestError/not-bud-after-cast');
     }
 
     function testRWA015OutputConduitPushWithNewBud() public {
-        address NEW_BUD = addr.addr("RWA015_A_CUSTODY_2");
+        address RWA015_A_CUSTODY_2 = addr.addr("RWA015_A_CUSTODY_2");
         RwaSwapOutputConduitLike outputConduit = RwaSwapOutputConduitLike(addr.addr("RWA015_A_OUTPUT_CONDUIT"));
         address psm = addr.addr("MCD_PSM_USDC_A");
         GemAbstract psmGem = GemAbstract(addr.addr("USDC"));
@@ -901,7 +901,7 @@ contract DssSpellTest is DssSpellTestBase {
         uint256 daiPsmGemDiffDecimals = 10 ** (18 - uint256(psmGem.decimals()));
 
         // Record psmGem balance before push
-        uint256 psmBalanceBeforePush = psmGem.balanceOf(NEW_BUD);
+        uint256 psmBalanceBeforePush = psmGem.balanceOf(RWA015_A_CUSTODY_2);
 
         uint256 amountToPush = 3;
 
@@ -912,21 +912,21 @@ contract DssSpellTest is DssSpellTestBase {
         // Setup DAI in Output Conduit
         GodMode.setBalance(address(dai), address(outputConduit), amountToPush * daiPsmGemDiffDecimals);
 
-        // Setup operator for OutputConduit
+        // Setup OutputConduit
         GodMode.setWard(address(outputConduit), address(this), 1);
         outputConduit.hope(address(this));
         outputConduit.mate(address(this));
 
         // Prepare for the push
-        outputConduit.pick(NEW_BUD);
+        outputConduit.pick(RWA015_A_CUSTODY_2);
         outputConduit.hook(psm);
 
         // Push and quit
         outputConduit.push(amountToPush * daiPsmGemDiffDecimals);
         outputConduit.quit();
 
-        assertEq(dai.balanceOf(address(outputConduit)), 0, "RWA015-A: Output conduit still holds Dai after quit()");
-        assertEq(psmGem.balanceOf(NEW_BUD) - psmBalanceBeforePush, amountToPush, "RWA015-A: Psm GEM not sent to destination after push()");
+        assertEq(dai.balanceOf(address(outputConduit)), 0, "RWA015_A_CUSTODY_2: Output conduit still holds Dai after quit()");
+        assertEq(psmGem.balanceOf(RWA015_A_CUSTODY_2) - psmBalanceBeforePush, amountToPush, "RWA015_A_CUSTODY_2: Psm GEM not sent to destination after push()");
     }
 
     function testPushPAXOutInputConduit() public {

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -46,8 +46,6 @@ interface SpellActionLike {
 
 interface RwaSwapOutputConduitLike {
     function bud(address) external view returns (uint256);
-    function mate(address) external;
-    function hope(address) external;
     function hook(address) external;
     function pick(address) external;
     function push(uint256) external;
@@ -890,8 +888,9 @@ contract DssSpellTest is DssSpellTestBase {
         assertEq(rwa015AOutputConduit.bud(RWA015_A_CUSTODY_2), 1, 'TestError/not-bud-after-cast');
     }
 
-    function testRWA015OutputConduitPushWithNewBud(address condiutOperator) public {
+    function testRWA015OutputConduitPushWithNewBud() public {
         address NEW_BUD = addr.addr("RWA015_A_CUSTODY_2");
+        address condiutOperator = addr.addr("RWA015_A_OPERATOR");
         RwaSwapOutputConduitLike outputConduit = RwaSwapOutputConduitLike(addr.addr("RWA015_A_OUTPUT_CONDUIT"));
         address psm = addr.addr("MCD_PSM_USDC_A");
         GemAbstract psmGem = GemAbstract(addr.addr("USDC"));
@@ -908,13 +907,8 @@ contract DssSpellTest is DssSpellTestBase {
         _scheduleWaitAndCast(address(spell));
         assertTrue(spell.done());
 
-        // Setup DAI in Output Conduit
+        // Set outputConduit balance
         GodMode.setBalance(address(dai), address(outputConduit), amountToPush * daiPsmGemDiffDecimals);
-
-        // Setup condiutOperator for OutputConduit
-        GodMode.setWard(address(outputConduit), address(this), 1);
-        outputConduit.hope(condiutOperator);
-        outputConduit.mate(condiutOperator);
 
         vm.startPrank(condiutOperator);
         {

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -404,15 +404,15 @@ contract DssSpellTest is DssSpellTestBase {
         uint256 amount;
     }
 
-    function testDAIPayments() public skipped { // add the `skipped` modifier to skip
+    function testDAIPayments() public { // add the `skipped` modifier to skip
         // For each payment, create a Payee object with
         //    the Payee address,
         //    the amount to be paid in whole Dai units
         // Initialize the array with the number of payees
         Payee[1] memory payees = [
-            Payee(wallets.addr("AAVE_V3_TREASURY"), 100_603)
+            Payee(wallets.addr("AAVE_V3_TREASURY"), 238_339)
         ];
-        uint256 expectedSumPayments = 100_603; // Fill the number with the value from exec doc.
+        uint256 expectedSumPayments = 238_339; // Fill the number with the value from exec doc.
 
         uint256 prevBalance;
         uint256 totAmount;
@@ -840,9 +840,10 @@ contract DssSpellTest is DssSpellTestBase {
 
     // SPARK TESTS
 
-    function testSparkSpellIsExecuted() public skipped { // add the `skipped` modifier to skip
+    function testSparkSpellIsExecuted() public { // add the `skipped` modifier to skip
         address SPARK_PROXY = addr.addr('SPARK_PROXY');
-        address SPARK_SPELL = 0x7748C5E6EEda836247F2AfCd5a7c0dA3c5de9Da2;
+        // TODO: Update with the correct spell address
+        address SPARK_SPELL = address(0);
 
         vm.expectCall(
             SPARK_PROXY,
@@ -860,4 +861,20 @@ contract DssSpellTest is DssSpellTestBase {
 
     // SPELL-SPECIFIC TESTS GO BELOW
 
+    function testPushPAXOutInputConduit() public {
+        DSTokenAbstract gem = DSTokenAbstract(addr.addr("PAX"));
+        address MCD_PSM_PAX_A_INPUT_CONDUIT_JAR = addr.addr("MCD_PSM_PAX_A_INPUT_CONDUIT_JAR");
+        uint256 prevDai = vat.dai(address(vow));
+        uint256 gemBalanceToPush = 84_211.27 ether; // `ether` is only a keyword helper
+
+        assertEq(gem.balanceOf(MCD_PSM_PAX_A_INPUT_CONDUIT_JAR), gemBalanceToPush);
+
+        _vote(address(spell));
+        _scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        // Note: other actions in the spell call drip under the hood, therefore asserting complete equality is not possible
+        assertGe(vat.dai(address(vow)), prevDai + gemBalanceToPush * RAY);
+        assertEq(gem.balanceOf(MCD_PSM_PAX_A_INPUT_CONDUIT_JAR), 0);
+    }
 }

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -869,7 +869,7 @@ contract DssSpellTest is DssSpellTestBase {
     // SPELL-SPECIFIC TESTS GO BELOW
 
     function testRWA015NewBud() public {
-        address NEW_BUD = addr.addr("RWA015_A_CUSTODY_TACO");
+        address NEW_BUD = addr.addr("RWA015_A_CUSTODY_2");
 
         RwaOutputConduitAbstract rwa015AOutputConduit = RwaOutputConduitAbstract(addr.addr("RWA015_A_OUTPUT_CONDUIT"));
         assertEq(rwa015AOutputConduit.bud(NEW_BUD), 0, 'TestError/already-bud');

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -587,25 +587,32 @@ contract DssSpellTest is DssSpellTestBase {
         }
     }
 
-    function testMKRPayments() public skipped { // add the `skipped` modifier to skip
+    function testMKRPayments() public { // add the `skipped` modifier to skip
         // For each payment, create a Payee object with
         //    the Payee address,
         //    the amount to be paid
         // Initialize the array with the number of payees
-        Payee[10] memory payees = [
-            Payee(wallets.addr("DEFENSOR"),    41.67 ether), // Note: ether is a keyword helper, only MKR is transferred here
-            Payee(wallets.addr("BLUE"),        41.67 ether), // Note: ether is a keyword helper, only MKR is transferred here
-            Payee(wallets.addr("BONAPUBLICA"), 41.67 ether), // Note: ether is a keyword helper, only MKR is transferred here
-            Payee(wallets.addr("CLOAKY"),      41.67 ether), // Note: ether is a keyword helper, only MKR is transferred here
-            Payee(wallets.addr("TRUENAME"),    41.67 ether), // Note: ether is a keyword helper, only MKR is transferred here
-            Payee(wallets.addr("PBG"),         13.89 ether), // Note: ether is a keyword helper, only MKR is transferred here
-            Payee(wallets.addr("UPMAKER"),     13.89 ether), // Note: ether is a keyword helper, only MKR is transferred here
-            Payee(wallets.addr("VIGILANT"),    13.89 ether), // Note: ether is a keyword helper, only MKR is transferred here
-            Payee(wallets.addr("WBC"),         13.89 ether), // Note: ether is a keyword helper, only MKR is transferred here
-            Payee(wallets.addr("JAG"),         13.71 ether)  // Note: ether is a keyword helper, only MKR is transferred here
+        Payee[17] memory payees = [
+            Payee(wallets.addr("BONAPUBLICA"),    41.67 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("CLOAKY"),         41.67 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("TRUENAME"),       41.67 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("BLUE"),           39.75 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("VIGILANT"),       13.89 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("PIPKIN"),         13.89 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("JAG"),            13.89 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("UPMAKER"),        12.93 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("IAMMEEOH"),       20.85 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("DAI_VINCI"),      20.85 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("OPENSKY_2"),      20.85 ether),  // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("ACREDAOS"),       20.85 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("RES"),            20.85 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("HARMONY_2"),      20.85 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("LIBERTAS"),       20.85 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("SEEDLATAMETH_2"), 20.85 ether), // Note: ether is a keyword helper, only MKR is transferred here
+            Payee(wallets.addr("ROOT"),           8.34 ether)  // Note: ether is a keyword helper, only MKR is transferred here
         ];
         // Fill the value below with the value from exec doc
-        uint256 expectedSumPayments = 277.62 ether; // Note: ether is a keyword helper, only MKR is transferred here
+        uint256 expectedSumPayments = 394.5 ether; // Note: ether is a keyword helper, only MKR is transferred here
 
         // Calculate and save previous balances
         uint256 totalAmountToTransfer = 0; // Increment in the loop below
@@ -861,11 +868,24 @@ contract DssSpellTest is DssSpellTestBase {
 
     // SPELL-SPECIFIC TESTS GO BELOW
 
+    function testRWA015NewBud() public {
+        address NEW_BUD = addr.addr("RWA015_A_CUSTODY_TACO");
+
+        RwaOutputConduitAbstract rwa015AOutputConduit = RwaOutputConduitAbstract(addr.addr("RWA015_A_OUTPUT_CONDUIT"));
+        assertEq(rwa015AOutputConduit.bud(NEW_BUD), 0, 'TestError/already-bud');
+
+        _vote(address(spell));
+        _scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        assertEq(rwa015AOutputConduit.bud(NEW_BUD), 1, 'TestError/not-bud-after-cast');
+    }
+
     function testPushPAXOutInputConduit() public {
         DSTokenAbstract gem = DSTokenAbstract(addr.addr("PAX"));
         address MCD_PSM_PAX_A_INPUT_CONDUIT_JAR = addr.addr("MCD_PSM_PAX_A_INPUT_CONDUIT_JAR");
         uint256 prevDai = vat.dai(address(vow));
-        uint256 gemBalanceToPush = 84_211.27 ether; // `ether` is only a keyword helper
+        uint256 gemBalanceToPush = 84_211.27 ether; // Note: `ether` is only a keyword helper
 
         assertEq(gem.balanceOf(MCD_PSM_PAX_A_INPUT_CONDUIT_JAR), gemBalanceToPush);
 

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -859,7 +859,7 @@ contract DssSpellTest is DssSpellTestBase {
 
     function testSparkSpellIsExecuted() public { // add the `skipped` modifier to skip
         address SPARK_PROXY = addr.addr('SPARK_PROXY');
-        address SPARK_SPELL =0x3d1DD14Fa08163E7f64b0abf0F514f6276f50882;
+        address SPARK_SPELL = 0x3d1DD14Fa08163E7f64b0abf0F514f6276f50882;
 
         vm.expectCall(
             SPARK_PROXY,

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -877,61 +877,6 @@ contract DssSpellTest is DssSpellTestBase {
 
     // SPELL-SPECIFIC TESTS GO BELOW
 
-    function testRWA015NewBud() public {
-        address RWA015_A_CUSTODY_2 = addr.addr("RWA015_A_CUSTODY_2");
-        RwaSwapOutputConduitLike rwa015AOutputConduit = RwaSwapOutputConduitLike(addr.addr("RWA015_A_OUTPUT_CONDUIT"));
-
-        assertEq(rwa015AOutputConduit.bud(RWA015_A_CUSTODY_2), 0, 'TestError/already-bud');
-
-        _vote(address(spell));
-        _scheduleWaitAndCast(address(spell));
-        assertTrue(spell.done());
-
-        assertEq(rwa015AOutputConduit.bud(RWA015_A_CUSTODY_2), 1, 'TestError/not-bud-after-cast');
-    }
-
-    function testRWA015OutputConduitPushWithNewBud(address condiutOperator) public {
-        address NEW_BUD = addr.addr("RWA015_A_CUSTODY_2");
-        RwaSwapOutputConduitLike outputConduit = RwaSwapOutputConduitLike(addr.addr("RWA015_A_OUTPUT_CONDUIT"));
-        address psm = addr.addr("MCD_PSM_USDC_A");
-        GemAbstract psmGem = GemAbstract(addr.addr("USDC"));
-
-        // Calculate difference of decimals
-        uint256 daiPsmGemDiffDecimals = 10 ** (18 - uint256(psmGem.decimals()));
-
-        // Record psmGem balance before push
-        uint256 psmBalanceBeforePush = psmGem.balanceOf(NEW_BUD);
-
-        uint256 amountToPush = 3;
-
-        _vote(address(spell));
-        _scheduleWaitAndCast(address(spell));
-        assertTrue(spell.done());
-
-        // Setup DAI in Output Conduit
-        GodMode.setBalance(address(dai), address(outputConduit), amountToPush * daiPsmGemDiffDecimals);
-
-        // Setup condiutOperator for OutputConduit
-        GodMode.setWard(address(outputConduit), address(this), 1);
-        outputConduit.hope(condiutOperator);
-        outputConduit.mate(condiutOperator);
-
-        vm.startPrank(condiutOperator);
-        {
-            // Prepare for the push
-            outputConduit.pick(NEW_BUD);
-            outputConduit.hook(psm);
-
-            // Push and quit
-            outputConduit.push(amountToPush * daiPsmGemDiffDecimals);
-            outputConduit.quit();
-        }
-        vm.stopPrank();
-
-        assertEq(dai.balanceOf(address(outputConduit)), 0, "RWA015_A: Output conduit still holds Dai after quit()");
-        assertEq(psmGem.balanceOf(NEW_BUD) - psmBalanceBeforePush, amountToPush, "RWA015_A: Psm GEM not sent to destination after push()");
-    }
-
     function testPushPAXOutInputConduit() public {
         DSTokenAbstract gem = DSTokenAbstract(addr.addr("PAX"));
         address MCD_PSM_PAX_A_INPUT_CONDUIT_JAR = addr.addr("MCD_PSM_PAX_A_INPUT_CONDUIT_JAR");

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -44,10 +44,6 @@ interface SpellActionLike {
     function dao_resolutions() external view returns (string memory);
 }
 
-interface LineMomLike {
-    function ilks(bytes32) external view returns (uint256);
-}
-
 contract DssSpellTest is DssSpellTestBase {
     string         config;
     RootDomain     rootDomain;
@@ -824,7 +820,7 @@ contract DssSpellTest is DssSpellTestBase {
         assertEq(Art, 0, "GUSD-A Art is not 0");
     }
 
-    function testDaoResolutions() public { // add the `skipped` modifier to skip
+    function testDaoResolutions() public skipped { // add the `skipped` modifier to skip
         // For each resolution, add IPFS hash as item to the resolutions array
         // Initialize the array with the number of resolutions
         string[1] memory resolutions = [
@@ -844,7 +840,7 @@ contract DssSpellTest is DssSpellTestBase {
 
     // SPARK TESTS
 
-    function testSparkSpellIsExecuted() public { // add the `skipped` modifier to skip
+    function testSparkSpellIsExecuted() public skipped { // add the `skipped` modifier to skip
         address SPARK_PROXY = addr.addr('SPARK_PROXY');
         address SPARK_SPELL = 0x7748C5E6EEda836247F2AfCd5a7c0dA3c5de9Da2;
 
@@ -864,31 +860,4 @@ contract DssSpellTest is DssSpellTestBase {
 
     // SPELL-SPECIFIC TESTS GO BELOW
 
-    function testLineMomAddedIlks() public {
-        LineMomLike lineMom = LineMomLike(chainLog.getAddress("LINE_MOM"));
-        string[8] memory addedIlks = [
-            "ETH-A",
-            "ETH-B",
-            "ETH-C",
-            "WSTETH-A",
-            "WSTETH-B",
-            "WBTC-A",
-            "WBTC-B",
-            "WBTC-C"
-        ];
-
-        for (uint256 i = 0; i < addedIlks.length; i++) {
-            uint256 exists = lineMom.ilks(_stringToBytes32(addedIlks[i]));
-            require(exists == 0, _concat("TestError/ilk-already-in-line-mom: ", addedIlks[i]));
-        }
-
-        _vote(address(spell));
-        _scheduleWaitAndCast(address(spell));
-        assertTrue(spell.done(), "TestError/spell-not-done");
-
-        for (uint256 i = 0; i < addedIlks.length; i++) {
-            uint256 exists = lineMom.ilks(_stringToBytes32(addedIlks[i]));
-            require(exists == 1, _concat("TestError/ilk-not-added-to-line-mom: ", addedIlks[i]));
-        }
-    }
 }

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -44,6 +44,16 @@ interface SpellActionLike {
     function dao_resolutions() external view returns (string memory);
 }
 
+interface RwaSwapOutputConduitLike {
+    function bud(address) external view returns (uint256);
+    function mate(address) external;
+    function hope(address) external;
+    function hook(address) external;
+    function pick(address) external;
+    function push(uint256) external;
+    function quit() external;
+}
+
 contract DssSpellTest is DssSpellTestBase {
     string         config;
     RootDomain     rootDomain;
@@ -866,6 +876,61 @@ contract DssSpellTest is DssSpellTestBase {
     }
 
     // SPELL-SPECIFIC TESTS GO BELOW
+
+    function testRWA015NewBud() public {
+        address RWA015_A_CUSTODY_2 = addr.addr("RWA015_A_CUSTODY_2");
+        RwaSwapOutputConduitLike rwa015AOutputConduit = RwaSwapOutputConduitLike(addr.addr("RWA015_A_OUTPUT_CONDUIT"));
+
+        assertEq(rwa015AOutputConduit.bud(RWA015_A_CUSTODY_2), 0, 'TestError/already-bud');
+
+        _vote(address(spell));
+        _scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        assertEq(rwa015AOutputConduit.bud(RWA015_A_CUSTODY_2), 1, 'TestError/not-bud-after-cast');
+    }
+
+    function testRWA015OutputConduitPushWithNewBud(address condiutOperator) public {
+        address NEW_BUD = addr.addr("RWA015_A_CUSTODY_2");
+        RwaSwapOutputConduitLike outputConduit = RwaSwapOutputConduitLike(addr.addr("RWA015_A_OUTPUT_CONDUIT"));
+        address psm = addr.addr("MCD_PSM_USDC_A");
+        GemAbstract psmGem = GemAbstract(addr.addr("USDC"));
+
+        // Calculate difference of decimals
+        uint256 daiPsmGemDiffDecimals = 10 ** (18 - uint256(psmGem.decimals()));
+
+        // Record psmGem balance before push
+        uint256 psmBalanceBeforePush = psmGem.balanceOf(NEW_BUD);
+
+        uint256 amountToPush = 3;
+
+        _vote(address(spell));
+        _scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        // Setup DAI in Output Conduit
+        GodMode.setBalance(address(dai), address(outputConduit), amountToPush * daiPsmGemDiffDecimals);
+
+        // Setup condiutOperator for OutputConduit
+        GodMode.setWard(address(outputConduit), address(this), 1);
+        outputConduit.hope(condiutOperator);
+        outputConduit.mate(condiutOperator);
+
+        vm.startPrank(condiutOperator);
+        {
+            // Prepare for the push
+            outputConduit.pick(NEW_BUD);
+            outputConduit.hook(psm);
+
+            // Push and quit
+            outputConduit.push(amountToPush * daiPsmGemDiffDecimals);
+            outputConduit.quit();
+        }
+        vm.stopPrank();
+
+        assertEq(dai.balanceOf(address(outputConduit)), 0, "RWA015_A: Output conduit still holds Dai after quit()");
+        assertEq(psmGem.balanceOf(NEW_BUD) - psmBalanceBeforePush, amountToPush, "RWA015_A: Psm GEM not sent to destination after push()");
+    }
 
     function testPushPAXOutInputConduit() public {
         DSTokenAbstract gem = DSTokenAbstract(addr.addr("PAX"));

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -857,7 +857,7 @@ contract DssSpellTest is DssSpellTestBase {
 
     function testSparkSpellIsExecuted() public { // add the `skipped` modifier to skip
         address SPARK_PROXY = addr.addr('SPARK_PROXY');
-        address SPARK_SPELL = 0x3d1DD14Fa08163E7f64b0abf0F514f6276f50882;
+        address SPARK_SPELL = 0x151D5fA7B3eD50098fFfDd61DB29cB928aE04C0e;
 
         vm.expectCall(
             SPARK_PROXY,

--- a/src/test/addresses_mainnet.sol
+++ b/src/test/addresses_mainnet.sol
@@ -413,6 +413,7 @@ contract Addresses {
         addr["RWA015_A_OUTPUT_CONDUIT"]          = 0x1E86CB085f249772f7e7443631a87c6BDba2aCEb;
         addr["RWA015_A_OPERATOR"]                = 0x23a10f09Fac6CCDbfb6d9f0215C795F9591D7476;
         addr["RWA015_A_CUSTODY"]                 = 0x65729807485F6f7695AF863d97D62140B7d69d83;
+        addr["RWA015_A_CUSTODY_2"]               = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
         addr["GUNIV3DAIUSDC1"]                   = 0xAbDDAfB225e10B90D798bB8A886238Fb835e2053;
         addr["PIP_GUNIV3DAIUSDC1"]               = 0x7F6d78CC0040c87943a0e0c140De3F77a273bd58;
         addr["MCD_JOIN_GUNIV3DAIUSDC1_A"]        = 0xbFD445A97e7459b0eBb34cfbd3245750Dba4d7a4;

--- a/src/test/addresses_mainnet.sol
+++ b/src/test/addresses_mainnet.sol
@@ -413,6 +413,7 @@ contract Addresses {
         addr["RWA015_A_OUTPUT_CONDUIT"]          = 0x1E86CB085f249772f7e7443631a87c6BDba2aCEb;
         addr["RWA015_A_OPERATOR"]                = 0x23a10f09Fac6CCDbfb6d9f0215C795F9591D7476;
         addr["RWA015_A_CUSTODY"]                 = 0x65729807485F6f7695AF863d97D62140B7d69d83;
+        addr["RWA015_A_CUSTODY_TACO"]            = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
         addr["GUNIV3DAIUSDC1"]                   = 0xAbDDAfB225e10B90D798bB8A886238Fb835e2053;
         addr["PIP_GUNIV3DAIUSDC1"]               = 0x7F6d78CC0040c87943a0e0c140De3F77a273bd58;
         addr["MCD_JOIN_GUNIV3DAIUSDC1_A"]        = 0xbFD445A97e7459b0eBb34cfbd3245750Dba4d7a4;

--- a/src/test/addresses_mainnet.sol
+++ b/src/test/addresses_mainnet.sol
@@ -413,7 +413,7 @@ contract Addresses {
         addr["RWA015_A_OUTPUT_CONDUIT"]          = 0x1E86CB085f249772f7e7443631a87c6BDba2aCEb;
         addr["RWA015_A_OPERATOR"]                = 0x23a10f09Fac6CCDbfb6d9f0215C795F9591D7476;
         addr["RWA015_A_CUSTODY"]                 = 0x65729807485F6f7695AF863d97D62140B7d69d83;
-        addr["RWA015_A_CUSTODY_TACO"]            = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
+        addr["RWA015_A_CUSTODY_2"]            = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
         addr["GUNIV3DAIUSDC1"]                   = 0xAbDDAfB225e10B90D798bB8A886238Fb835e2053;
         addr["PIP_GUNIV3DAIUSDC1"]               = 0x7F6d78CC0040c87943a0e0c140De3F77a273bd58;
         addr["MCD_JOIN_GUNIV3DAIUSDC1_A"]        = 0xbFD445A97e7459b0eBb34cfbd3245750Dba4d7a4;

--- a/src/test/addresses_mainnet.sol
+++ b/src/test/addresses_mainnet.sol
@@ -413,7 +413,6 @@ contract Addresses {
         addr["RWA015_A_OUTPUT_CONDUIT"]          = 0x1E86CB085f249772f7e7443631a87c6BDba2aCEb;
         addr["RWA015_A_OPERATOR"]                = 0x23a10f09Fac6CCDbfb6d9f0215C795F9591D7476;
         addr["RWA015_A_CUSTODY"]                 = 0x65729807485F6f7695AF863d97D62140B7d69d83;
-        addr["RWA015_A_CUSTODY_2"]            = 0x6759610547a36E9597Ef452aa0B9cace91291a2f;
         addr["GUNIV3DAIUSDC1"]                   = 0xAbDDAfB225e10B90D798bB8A886238Fb835e2053;
         addr["PIP_GUNIV3DAIUSDC1"]               = 0x7F6d78CC0040c87943a0e0c140De3F77a273bd58;
         addr["MCD_JOIN_GUNIV3DAIUSDC1_A"]        = 0xbFD445A97e7459b0eBb34cfbd3245750Dba4d7a4;

--- a/src/test/addresses_wallets.sol
+++ b/src/test/addresses_wallets.sol
@@ -85,6 +85,7 @@ contract Wallets {
         addr["OPENSKY_2"]                    = 0xf44f97f4113759E0a57756bE49C0655d490Cf19F;
         addr["DAVIDPHELPS"]                  = 0xd56e3E325133EFEd6B1687C88571b8a91e517ab0;
         addr["SEEDLATAMETH"]                 = 0x0087a081a9B430fd8f688c6ac5dD24421BfB060D;
+        addr["SEEDLATAMETH_2"]               = 0xd43b89621fFd48A8A51704f85fd0C87CbC0EB299;
         addr["STABLELAB_2"]                  = 0xbDE65cf2352ed1Dde959f290E973d0fC5cEDFD08;
         addr["FLIPSIDEGOV"]                  = 0x300901243d6CB2E74c10f8aB4cc89a39cC222a29;
         addr["DAI_VINCI"]                    = 0x9ee47F0f82F1A6F45C4E1D25Ce95C321D8C8356a;

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -137,7 +137,7 @@ contract Config {
             aL_ttl:       6 hours,         // In seconds
             line:         0,               // In whole Dai units  // Not checked here as there is auto line
             dust:         7_500,           // In whole Dai units
-            pct:          11_25,           // In basis points
+            pct:          10_25,           // In basis points
             mat:          14500,           // In basis points
             liqType:      "clip",          // "" or "flip" or "clip"
             liqOn:        true,            // If liquidations are enabled
@@ -162,7 +162,7 @@ contract Config {
             aL_ttl:       6 hours,
             line:         0,
             dust:         25 * THOUSAND,
-            pct:          11_75,
+            pct:          10_75,
             mat:          13000,
             liqType:      "clip",
             liqOn:        true,
@@ -187,7 +187,7 @@ contract Config {
             aL_ttl:       8 hours,
             line:         0,
             dust:         3_500,
-            pct:          11_00,
+            pct:          10_00,
             mat:          17000,
             liqType:      "clip",
             liqOn:        true,
@@ -287,7 +287,7 @@ contract Config {
             aL_ttl:       24 hours,
             line:         0,
             dust:         7_500,
-            pct:          12_75,
+            pct:          11_75,
             mat:          14500,
             liqType:      "clip",
             liqOn:        true,
@@ -312,7 +312,7 @@ contract Config {
             aL_ttl:       24 hours,
             line:         0,
             dust:         25 * THOUSAND,
-            pct:          13_25,
+            pct:          12_25,
             mat:          13000,
             liqType:      "clip",
             liqOn:        true,
@@ -337,7 +337,7 @@ contract Config {
             aL_ttl:       24 hours,
             line:         0,
             dust:         3_500,
-            pct:          12_50,
+            pct:          11_50,
             mat:          17500,
             liqType:      "clip",
             liqOn:        true,
@@ -1462,7 +1462,7 @@ contract Config {
             aL_ttl:       12 hours,
             line:         0,
             dust:         7_500,
-            pct:          12_25,
+            pct:          11_25,
             mat:          150_00,
             liqType:      "clip",
             liqOn:        true,
@@ -1487,7 +1487,7 @@ contract Config {
             aL_ttl:       12 hours,
             line:         0,
             dust:         3_500,
-            pct:          12_00,
+            pct:          11_00,
             mat:          175_00,
             liqType:      "clip",
             liqOn:        true,

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -106,7 +106,7 @@ contract Config {
         // Values for all system configuration changes
         //
         afterSpell.line_offset           = 680 * MILLION;  // Offset between the global line against the sum of local lines
-        afterSpell.pot_dsr               = 13_00;          // In basis points
+        afterSpell.pot_dsr               = 11_00;          // In basis points
         afterSpell.pause_delay           = 30 hours;       // In seconds
         afterSpell.vow_wait              = 156 hours;      // In seconds
         afterSpell.vow_dump              = 250;            // In whole Dai units
@@ -137,7 +137,7 @@ contract Config {
             aL_ttl:       6 hours,         // In seconds
             line:         0,               // In whole Dai units  // Not checked here as there is auto line
             dust:         7_500,           // In whole Dai units
-            pct:          13_25,           // In basis points
+            pct:          11_25,           // In basis points
             mat:          14500,           // In basis points
             liqType:      "clip",          // "" or "flip" or "clip"
             liqOn:        true,            // If liquidations are enabled
@@ -162,7 +162,7 @@ contract Config {
             aL_ttl:       6 hours,
             line:         0,
             dust:         25 * THOUSAND,
-            pct:          13_75,
+            pct:          11_75,
             mat:          13000,
             liqType:      "clip",
             liqOn:        true,
@@ -187,7 +187,7 @@ contract Config {
             aL_ttl:       8 hours,
             line:         0,
             dust:         3_500,
-            pct:          13_00,
+            pct:          11_00,
             mat:          17000,
             liqType:      "clip",
             liqOn:        true,
@@ -287,7 +287,7 @@ contract Config {
             aL_ttl:       24 hours,
             line:         0,
             dust:         7_500,
-            pct:          14_75,
+            pct:          12_75,
             mat:          14500,
             liqType:      "clip",
             liqOn:        true,
@@ -312,7 +312,7 @@ contract Config {
             aL_ttl:       24 hours,
             line:         0,
             dust:         25 * THOUSAND,
-            pct:          15_25,
+            pct:          13_25,
             mat:          13000,
             liqType:      "clip",
             liqOn:        true,
@@ -337,7 +337,7 @@ contract Config {
             aL_ttl:       24 hours,
             line:         0,
             dust:         3_500,
-            pct:          14_50,
+            pct:          12_50,
             mat:          17500,
             liqType:      "clip",
             liqOn:        true,
@@ -1462,7 +1462,7 @@ contract Config {
             aL_ttl:       12 hours,
             line:         0,
             dust:         7_500,
-            pct:          14_25,
+            pct:          12_25,
             mat:          150_00,
             liqType:      "clip",
             liqOn:        true,
@@ -1487,7 +1487,7 @@ contract Config {
             aL_ttl:       12 hours,
             line:         0,
             dust:         3_500,
-            pct:          14_00,
+            pct:          12_00,
             mat:          175_00,
             liqType:      "clip",
             liqOn:        true,

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -94,9 +94,9 @@ contract Config {
         // Values for spell-specific parameters
         //
         spellValues = SpellValues({
-            deployed_spell:         address(0x016e2848993CFbC952a93BA3D496162Afe703cA8), // populate with deployed spell if deployed
-            deployed_spell_created: 1712256719,          // use `make deploy-info tx=<deployment-tx>` to obtain the timestamp
-            deployed_spell_block:   19584298,          // use `make deploy-info tx=<deployment-tx>` to obtain the block number
+            deployed_spell:         address(0), // populate with deployed spell if deployed
+            deployed_spell_created: 0,          // use `make deploy-info tx=<deployment-tx>` to obtain the timestamp
+            deployed_spell_block:   0,          // use `make deploy-info tx=<deployment-tx>` to obtain the block number
             previous_spells:        prevSpells, // older spells to ensure are executed first
             office_hours_enabled:   false,      // true if officehours is expected to be enabled in the spell
             expiration_threshold:   30 days     // Amount of time before spell expires

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -106,7 +106,7 @@ contract Config {
         // Values for all system configuration changes
         //
         afterSpell.line_offset           = 680 * MILLION;  // Offset between the global line against the sum of local lines
-        afterSpell.pot_dsr               = 11_00;          // In basis points
+        afterSpell.pot_dsr               = 10_00;          // In basis points
         afterSpell.pause_delay           = 30 hours;       // In seconds
         afterSpell.vow_wait              = 156 hours;      // In seconds
         afterSpell.vow_dump              = 250;            // In whole Dai units


### PR DESCRIPTION
# Description
This PR implements 2024-04-18 mainnet spell based on the [relevant Exec Sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw/edit#gid=684547605).

# Contribution Checklist

- [ ] PR title starts with `(PE-<TICKET_NUMBER>)`
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier override
- [ ] Verify expiration (`30 days` unless otherwise specified)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell `ETH_GAS_LIMIT="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Verify `mainnet` contract on etherscan
- [ ] Change test to use mainnet spell address and deploy timestamp
- [ ] Run `make archive-spell` or `make date="YYYY-MM-DD" archive-spell` to make an archive directory and copy `DssSpell.sol`, `DssSpell.t.sol`, `DssSpell.t.base.sol`, and `DssSpellCollateralOnboarding.sol`
- [ ] `squash and merge` this PR
