### PR TITLE
Fix `cast-on-tenderly` script

### DIFF
--- a/scripts/cast-on-tenderly/index.js
+++ b/scripts/cast-on-tenderly/index.js
@@ -70,7 +70,7 @@ const createTenderlyTestnet = async function (spellName) {
     });
     const testnetId = response.data.container.id;
     const rpcEndpointPrivate = response.data.container.connectivityConfig.endpoints.find(
-        endpoint => endpoint.displayName === 'unlocked'
+        endpoint => endpoint.private === true
     );
     console.info(`tenderly testnet "${testnetId}" is created`);
     return {
@@ -93,7 +93,7 @@ const publishTenderlyTestnet = async function (testnetId) {
     }
     console.info(`tenderly testnet is now public and discoverable`);
     const rpcEndpointPublic = response.data.container.connectivityConfig.endpoints.find(
-        endpoint => endpoint.displayName === 'testnet'
+        endpoint => endpoint.private === false
     );
     const explorerUrlPublic = `https://dashboard.tenderly.co/explorer/vnet/${rpcEndpointPublic.id}`;
     console.info(`public explorer url: ${explorerUrlPublic}`);


### PR DESCRIPTION
Closes https://github.com/makerdao/spells-mainnet/issues/407

This PR fixes the problem with the `cast-on-tenderly` script reported in https://github.com/makerdao/spells-mainnet/issues/407. 

### Problem description

After creating Tenderly testnets, the endpoint returns an array of RPC endpoints within `container.connectivityConfig.endpoints` with two currently items: one which accepts cheat codes and one that doesn't. In order to get desired one, we initially used their internal `endpoints[].displayName` properly (as far as I remember, there were no dedicated properly to specify which one is which), but now they introduced `endpoints[].private` boolean which is also mentioned in the [API docs](https://tenderlydev.notion.site/API-Endpoints-d6c444c0f6934727a2297b958da19a4b#:~:text=endpoint%20that%20has-,private%20set%20to%20true,-.)

### Solution
Use documented `container.connectivityConfig.endpoints[].private` property to determine correct RPC network.