### PR TITLE
[MAINTENANCE] Fix: `check-deployed-spell` script

### DIFF
--- a/scripts/check-deployed-dssspell.sh
+++ b/scripts/check-deployed-dssspell.sh
@@ -19,7 +19,7 @@ function error_check() {
 [[ "$ETHERSCAN_API_KEY" ]] || { echo -e "Please set ETHERSCAN_API_KEY"; exit 1; }
 
 # Etherscan API endpoint
-ETHERSCAN_API="https://api.etherscan.io/api"
+ETHERSCAN_API="https://api.etherscan.io/api?apikey=$ETHERSCAN_API_KEY"
 
 # Path to config.sol file
 CONFIG_PATH="src/test/config.sol"
@@ -40,7 +40,7 @@ if [[ "$deployed_spell_address" =~ ^(address\(0\)|0)$ ]] || [[ "$deployed_spell_
 fi
 
 # Get spell verification information
-verified_spell_info=$(curl -s "$ETHERSCAN_API?module=contract&action=getsourcecode&address=$deployed_spell_address" | jq -r .result[0])
+verified_spell_info=$(curl -s "$ETHERSCAN_API&module=contract&action=getsourcecode&address=$deployed_spell_address" | jq -r .result[0])
 
 # Check spell verification status
 verified=$(echo "$verified_spell_info" | jq -r '.SourceCode != null')
@@ -84,7 +84,7 @@ else
 fi
 
 # Retrieve transaction hash
-tx_hash=$(curl -s "$ETHERSCAN_API?module=account&action=txlistinternal&address=$deployed_spell_address&startblock=0&endblock=99999999&sort=asc&apikey=$ETHERSCAN_API_KEY" | jq -r ".result[0].hash")
+tx_hash=$(curl -s "$ETHERSCAN_API&module=account&action=txlistinternal&address=$deployed_spell_address&startblock=0&endblock=99999999&sort=asc" | jq -r ".result[0].hash")
 
 # Retrieve deployed spell timestamp and block number info
 timestamp=$(cast block "$(cast tx "${tx_hash}"|grep blockNumber|awk '{print $2}')"|grep timestamp|awk '{print $2}')

--- a/scripts/check-deployed-dssspell.sh
+++ b/scripts/check-deployed-dssspell.sh
@@ -29,9 +29,9 @@ LICENSE="GNU AGPLv3"
 SOLC="v0.8.16+commit.07a7930e"
 
 # Read spell address, block number, and timestamp from config.sol
-deployed_spell_address=$(grep -oE 'deployed_spell:\s+address\((0x[a-fA-F0-9]+)\)' $CONFIG_PATH | sed -E 's/^.*\((.*)\)/\1/')
-deployed_spell_block=$(grep -oE 'deployed_spell_block\s*:\s*[0-9]+' $CONFIG_PATH | sed -E 's/.*:\s*//')
-deployed_spell_timestamp=$(grep -oE 'deployed_spell_created\s*:\s*[0-9]+' $CONFIG_PATH | sed -E 's/.*:\s*//')
+deployed_spell_address=$(grep -oE 'deployed_spell:\s+address\((0x[a-fA-F0-9]+)\)' $CONFIG_PATH | grep -o '0x[a-fA-F0-9]\+')
+deployed_spell_block=$(grep -oE 'deployed_spell_block\s*:\s*[0-9]+' $CONFIG_PATH | grep -o '[0-9]\+')
+deployed_spell_timestamp=$(grep -oE 'deployed_spell_created\s*:\s*[0-9]+' $CONFIG_PATH | grep -o '[0-9]\+')
 
 # Check if spell address, block number, and timestamp are zero
 if [[ "$deployed_spell_address" =~ ^(address\(0\)|0)$ ]] || [[ "$deployed_spell_block" = "0" ]] || [[ "$deployed_spell_timestamp" = "0" ]]; then


### PR DESCRIPTION
# Description

# Contribution Checklist

- [ ] PR title starts with `(PE-<TICKET_NUMBER>)`
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Consider if this PR needs the `officeHours` modifier override
- [ ] Verify expiration (`30 days` unless otherwise specified)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in changelog or known
- [ ] Notify any external teams affected by the spell so they have the opportunity to review
- [ ] Deploy spell `ETH_GAS_LIMIT="XXX" ETH_GAS_PRICE="YYY" make deploy`
- [ ] Verify `mainnet` contract on etherscan
- [ ] Change test to use mainnet spell address and deploy timestamp
- [ ] Run `make archive-spell` or `make date="YYYY-MM-DD" archive-spell` to make an archive directory and copy `DssSpell.sol`, `DssSpell.t.sol`, `DssSpell.t.base.sol`, and `DssSpellCollateralOnboarding.sol`
- [ ] `squash and merge` this PR
