### PR TITLE
Chore: fix compiler warnings

### DIFF
--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -2842,7 +2842,19 @@ contract DssSpellTestBase is Config, DssTest {
         actualBytecodeSize -= metadataLength;
 
         assertEq(actualBytecodeSize, expectedBytecodeSize, "TestError/bytecode-size-mismatch");
-        assertEq(actualAction.codehash, expectedAction.codehash, "TestError/bytecode-hash-mismatch");
+        uint256 size = actualBytecodeSize;
+        uint256 expectedHash;
+        uint256 actualHash;
+        assembly {
+            let ptr := mload(0x40)
+
+            extcodecopy(expectedAction, ptr, 0, size)
+            expectedHash := keccak256(ptr, size)
+
+            extcodecopy(actualAction, ptr, 0, size)
+            actualHash := keccak256(ptr, size)
+        }
+        assertEq(actualHash, expectedHash, "TestError/bytecode-hash-mismatch");
     }
 
     struct ChainlogCache {

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -1033,7 +1033,7 @@ contract DssSpellTest is DssSpellTestBase {
         assertEq(Art, 0, "GUSD-A Art is not 0");
     }
 
-    function testDaoResolutions() public { // add the `skipped` modifier to skip
+    function testDaoResolutions() public view { // replace `view` with the `skipped` modifier to skip
         // For each resolution, add IPFS hash as item to the resolutions array
         // Initialize the array with the number of resolutions
         string[1] memory resolutions = [


### PR DESCRIPTION
Currently we get the following compiler warnings when running the spell tests:

```
./scripts/test-dssspell-forge.sh no-match="" match="testDaoResolutions" block=""
Using DssExecLib at: 0x8De6DDbCd5053d32292AAA0D2105A32d108484a6
[⠊] Compiling...
[⠃] Compiling 3 files with Solc 0.8.16
[⠊] Solc 0.8.16 finished in 2.77s
Compiler run successful with warnings:
Warning (2018): Function state mutability can be restricted to view
   --> src/DssSpell.t.base.sol:983:5:
    |
983 |     function _getOSMPrice(address pip) internal returns (uint256) {
    |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (2018): Function state mutability can be restricted to view
   --> src/DssSpell.t.base.sol:999:5:
    |
999 |     function _getUNIV2LPPrice(address pip) internal returns (uint256) {
    |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (2018): Function state mutability can be restricted to pure
    --> src/DssSpell.t.base.sol:2174:5:
     |
2174 |     function _getSignatures(bytes32 signHash) internal returns (bytes memory signatures, address[] memory signers) {
     |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (2018): Function state mutability can be restricted to view
    --> src/DssSpell.t.base.sol:2366:5:
     |
2366 |     function _checkTransferrableVestMkrAllowance() internal {
     |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (2018): Function state mutability can be restricted to view
    --> src/DssSpell.t.base.sol:2722:5:
     |
2722 |     function _testContractSize() internal {
     |     ^ (Relevant source part starts here and spans across multiple lines).

Warning (2018): Function state mutability can be restricted to view
    --> src/DssSpell.t.sol:1036:5:
     |
1036 |     function testDaoResolutions() public { // add the `skipped` modifier to skip
     |     ^ (Relevant source part starts here and spans across multiple lines).
```

Notice that `testDaoResolutions` can be restricted to `view` **if** it doesn't have the `skipped` modifier to it, as `vm.skip()` is not a view function. In this case, we could simply ignore the warning or update the instruction to replace the `view` modifier with `skipped` when necessary.

I also took the opportunity to make some small improvements on the base tests.