### PR TITLE
fix: cast-on-tenderly script

### DIFF
--- a/scripts/cast-on-tenderly/index.js
+++ b/scripts/cast-on-tenderly/index.js
@@ -85,7 +85,9 @@ const publishTenderlyTestnet = async function (testnetId) {
         method: 'put',
         path: `/testnet/container/${testnetId}`,
         body: {
-            explorerPage: 'ENABLED',
+            explorerConfig: {
+                enabled: true,
+            },
         },
     });
     if (response.data?.container?.explorer_page !== 'ENABLED') {


### PR DESCRIPTION
This PR closes #452. 

As outlined in the issue, there was some changes introduced in tenderly API which made our script failed on last stage (`publishTenderlyTestnet`). 
The suggested change in issue was confirmed during last spell deployment and included in the current PR. 
