### PR TITLE
fix: Add a new function to fix the chronicle price returning a stale value

### DIFF
--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -26,9 +26,9 @@ export FOUNDRY_ROOT_CHAINID=1
 TEST_ARGS=''
 
 if [[ -n "$MATCH" ]]; then
-    TEST_ARGS="${TEST_ARGS} -vvv --match-test ${MATCH}"
+    TEST_ARGS="${TEST_ARGS} -vvvv --match-test ${MATCH}"
 elif [[ -n "$NO_MATCH" ]]; then
-    TEST_ARGS="${TEST_ARGS} -vvv --no-match-test ${NO_MATCH}"
+    TEST_ARGS="${TEST_ARGS} -vvvv --no-match-test ${NO_MATCH}"
 fi
 
 if [[ -n "$BLOCK" ]]; then

--- a/scripts/test-dssspell-forge.sh
+++ b/scripts/test-dssspell-forge.sh
@@ -26,9 +26,9 @@ export FOUNDRY_ROOT_CHAINID=1
 TEST_ARGS=''
 
 if [[ -n "$MATCH" ]]; then
-    TEST_ARGS="${TEST_ARGS} -vvvv --match-test ${MATCH}"
+    TEST_ARGS="${TEST_ARGS} -vvv --match-test ${MATCH}"
 elif [[ -n "$NO_MATCH" ]]; then
-    TEST_ARGS="${TEST_ARGS} -vvvv --no-match-test ${NO_MATCH}"
+    TEST_ARGS="${TEST_ARGS} -vvv --no-match-test ${NO_MATCH}"
 fi
 
 if [[ -n "$BLOCK" ]]; then

--- a/src/DssSpell.sol
+++ b/src/DssSpell.sol
@@ -254,7 +254,7 @@ contract DssSpellAction is DssAction {
 
         // Trigger Spark Proxy Spell at 0xBeA5FA2bFC4F6a0b6060Eb8EC23F25db8259cEE0
         // Note: Make sure to not revert the Core spell if the Spark spell reverts
-        try ProxyLike(SPARK_PROXY).exec(SPARK_SPELL, abi.encodeWithSignature("execute()")) {} catch {}
+        ProxyLike(SPARK_PROXY).exec(SPARK_SPELL, abi.encodeWithSignature("execute()"));
 
         // ---------- Chainlog bump ----------
 

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -3589,9 +3589,9 @@ contract DssSpellTestBase is Config, DssTest {
         bytes32 pokeData     = vm.load(oracle, pokeDataSlot);
         uint128 pokePrice    = uint128(bytes16(pokeData << 128));
 
-        uint32 expiresAt = 365 days * 100;
+        uint256 expiresAt = 365 days * 100;
 
-        vm.store(oracle, pokeDataSlot, bytes32(uint256(expiresAt) << 128 | uint256(pokePrice)));
+        vm.store(oracle, pokeDataSlot, bytes32(expiresAt << 128 | uint256(pokePrice)));
     }
 
     function _fixChronicleStaleness() internal {

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -648,26 +648,26 @@ contract DssSpellTestBase is Config, DssTest {
             ?  DssSpell(spellValues.deployed_spell)
             : new DssSpell();
 
-        if (spellValues.deployed_spell_block != 0 && spell.eta() != 0) {
-            // if we have a deployed spell in the config
-            // we want to roll our fork to the block where it was deployed
-            // this means the test suite will continue to accurately pass/fail
-            // even if mainnet has already scheduled/cast the spell
-            vm.makePersistent(address(rates));
-            vm.makePersistent(address(addr));
-            vm.makePersistent(address(deployers));
-            vm.makePersistent(address(wallets));
-            vm.rollFork(spellValues.deployed_spell_block);
+        // if (spellValues.deployed_spell_block != 0 && spell.eta() != 0) {
+        //     // if we have a deployed spell in the config
+        //     // we want to roll our fork to the block where it was deployed
+        //     // this means the test suite will continue to accurately pass/fail
+        //     // even if mainnet has already scheduled/cast the spell
+        //     vm.makePersistent(address(rates));
+        //     vm.makePersistent(address(addr));
+        //     vm.makePersistent(address(deployers));
+        //     vm.makePersistent(address(wallets));
+        //     vm.rollFork(spellValues.deployed_spell_block);
 
-            // Reset `eta` to `0`, otherwise the tests will fail with "This spell has already been scheduled".
-            // This is a workaround for the issue described here:
-            // @see { https://github.com/foundry-rs/foundry/issues/5739 }
-            vm.store(
-                address(spell),
-                bytes32(0),
-                bytes32(0)
-            );
-        }
+        //     // Reset `eta` to `0`, otherwise the tests will fail with "This spell has already been scheduled".
+        //     // This is a workaround for the issue described here:
+        //     // @see { https://github.com/foundry-rs/foundry/issues/5739 }
+        //     vm.store(
+        //         address(spell),
+        //         bytes32(0),
+        //         bytes32(0)
+        //     );
+        // }
     }
 
     function _vote(address spell_) internal {

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -648,26 +648,26 @@ contract DssSpellTestBase is Config, DssTest {
             ?  DssSpell(spellValues.deployed_spell)
             : new DssSpell();
 
-        // if (spellValues.deployed_spell_block != 0 && spell.eta() != 0) {
-        //     // if we have a deployed spell in the config
-        //     // we want to roll our fork to the block where it was deployed
-        //     // this means the test suite will continue to accurately pass/fail
-        //     // even if mainnet has already scheduled/cast the spell
-        //     vm.makePersistent(address(rates));
-        //     vm.makePersistent(address(addr));
-        //     vm.makePersistent(address(deployers));
-        //     vm.makePersistent(address(wallets));
-        //     vm.rollFork(spellValues.deployed_spell_block);
+        if (spellValues.deployed_spell_block != 0 && spell.eta() != 0) {
+            // if we have a deployed spell in the config
+            // we want to roll our fork to the block where it was deployed
+            // this means the test suite will continue to accurately pass/fail
+            // even if mainnet has already scheduled/cast the spell
+            vm.makePersistent(address(rates));
+            vm.makePersistent(address(addr));
+            vm.makePersistent(address(deployers));
+            vm.makePersistent(address(wallets));
+            vm.rollFork(spellValues.deployed_spell_block);
 
-        //     // Reset `eta` to `0`, otherwise the tests will fail with "This spell has already been scheduled".
-        //     // This is a workaround for the issue described here:
-        //     // @see { https://github.com/foundry-rs/foundry/issues/5739 }
-        //     vm.store(
-        //         address(spell),
-        //         bytes32(0),
-        //         bytes32(0)
-        //     );
-        // }
+            // Reset `eta` to `0`, otherwise the tests will fail with "This spell has already been scheduled".
+            // This is a workaround for the issue described here:
+            // @see { https://github.com/foundry-rs/foundry/issues/5739 }
+            vm.store(
+                address(spell),
+                bytes32(0),
+                bytes32(0)
+            );
+        }
     }
 
     function _vote(address spell_) internal {

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -3584,6 +3584,24 @@ contract DssSpellTestBase is Config, DssTest {
         }
     }
 
+    function _fixChronicleStaleness(address oracle) internal {
+        bytes32 pokeDataSlot = bytes32(uint256(4));
+        bytes32 pokeData     = vm.load(oracle, pokeDataSlot);
+        uint128 pokePrice    = uint128(bytes16(pokeData << 128));
+
+        uint32 expiresAt = 365 days * 100;
+
+        vm.store(oracle, pokeDataSlot, bytes32(uint256(expiresAt) << 128 | uint256(pokePrice)));
+    }
+
+    function _fixChronicleStaleness() internal {
+        address chronicleBtc = 0x24C392CDbF32Cf911B258981a66d5541d85269ce;
+        address chronicleEth = 0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E;
+
+        _fixChronicleStaleness(chronicleBtc);
+        _fixChronicleStaleness(chronicleEth);
+    }
+
     // Obtained as `bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)`
     bytes32 constant EIP1967_IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -893,30 +893,6 @@ contract DssSpellTest is DssSpellTestBase {
         }
     }
 
-    function _fixChronicleStaleness(address oracle) private {
-        bytes32 pokeDataSlot   = bytes32(uint256(4));
-        bytes32 opPokeDataSlot = bytes32(uint256(518));
-
-        bytes32 pokeData   = vm.load(oracle, pokeDataSlot);
-        bytes32 opPokeData = vm.load(oracle, opPokeDataSlot);
-
-        uint32  expiresAt = 365 days * 100;
-
-        uint128 pokePrice   = uint128(bytes16(pokeData << 128));
-        uint128 opPokePrice = uint128(bytes16(opPokeData << 128));
-
-        vm.store(oracle, pokeDataSlot,   bytes32(uint256(expiresAt) << 128 | uint256(pokePrice)));
-        vm.store(oracle, opPokeDataSlot, bytes32(uint256(expiresAt) << 128 | uint256(opPokePrice)));
-    }
-
-    function _fixChronicleStaleness() private {
-        address chronicleBtc = 0x24C392CDbF32Cf911B258981a66d5541d85269ce;
-        address chronicleEth = 0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E;
-
-        _fixChronicleStaleness(chronicleBtc);
-        _fixChronicleStaleness(chronicleEth);
-    }
-
     function test_chronicleStalenessFix() public {
         _fixChronicleStaleness();
         _vote(address(spell));

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -50,6 +50,12 @@ interface LineMomLike {
 }
 
 contract DssSpellTest is DssSpellTestBase {
+
+    function setUp() public override {
+        super.setUp();
+        _fixChronicleStaleness();
+    }
+
     // DO NOT TOUCH THE FOLLOWING TESTS, THEY SHOULD BE RUN ON EVERY SPELL
     function testGeneral() public {
         _testGeneral();

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -16,23 +16,8 @@
 
 pragma solidity 0.8.16;
 
-import { console } from "forge-std/console.sol";
-
 import "./DssSpell.t.base.sol";
 import {ScriptTools} from "dss-test/DssTest.sol";
-
-interface IOracle {
-    function latestRoundData()
-        external
-        view
-        returns (
-            uint80 roundId,
-            int answer,
-            uint startedAt,
-            uint updatedAt,
-            uint80 answeredInRound
-        );
-}
 
 interface L2Spell {
     function dstDomain() external returns (bytes32);
@@ -932,7 +917,7 @@ contract DssSpellTest is DssSpellTestBase {
         _fixChronicleStaleness(chronicleEth);
     }
 
-    function test_spell() public {
+    function test_chronicleStalenessFix() public {
         _fixChronicleStaleness();
         _vote(address(spell));
         _scheduleWaitAndCast(address(spell));

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -16,8 +16,23 @@
 
 pragma solidity 0.8.16;
 
+import { console } from "forge-std/console.sol";
+
 import "./DssSpell.t.base.sol";
 import {ScriptTools} from "dss-test/DssTest.sol";
+
+interface IOracle {
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int answer,
+            uint startedAt,
+            uint updatedAt,
+            uint80 answeredInRound
+        );
+}
 
 interface L2Spell {
     function dstDomain() external returns (bytes32);
@@ -891,6 +906,37 @@ contract DssSpellTest is DssSpellTestBase {
                 revert('TestPayments/unexpected-payee-token');
             }
         }
+    }
+
+    function _fixChronicleStaleness(address oracle) private {
+        bytes32 pokeDataSlot   = bytes32(uint256(4));
+        bytes32 opPokeDataSlot = bytes32(uint256(518));
+
+        bytes32 pokeData   = vm.load(oracle, pokeDataSlot);
+        bytes32 opPokeData = vm.load(oracle, opPokeDataSlot);
+
+        uint32  expiresAt = 365 days * 100;
+
+        uint128 pokePrice   = uint128(bytes16(pokeData << 128));
+        uint128 opPokePrice = uint128(bytes16(opPokeData << 128));
+
+        vm.store(oracle, pokeDataSlot,   bytes32(uint256(expiresAt) << 128 | uint256(pokePrice)));
+        vm.store(oracle, opPokeDataSlot, bytes32(uint256(expiresAt) << 128 | uint256(opPokePrice)));
+    }
+
+    function _fixChronicleStaleness() private {
+        address chronicleBtc = 0x24C392CDbF32Cf911B258981a66d5541d85269ce;
+        address chronicleEth = 0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E;
+
+        _fixChronicleStaleness(chronicleBtc);
+        _fixChronicleStaleness(chronicleEth);
+    }
+
+    function test_spell() public {
+        _fixChronicleStaleness();
+        _vote(address(spell));
+        _scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done(), "TestError/spell-not-done");
     }
 
     function testNewCronJobs() public skipped { // add the `skipped` modifier to skip

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -107,7 +107,7 @@ contract Config {
         //
         spellValues = SpellValues({
             deployed_spell:         address(0), // populate with deployed spell if deployed
-            deployed_spell_created: 0, // use `make deploy-info tx=<deployment-tx>` to obtain the timestamp
+            deployed_spell_created: 0,          // use `make deploy-info tx=<deployment-tx>` to obtain the timestamp
             deployed_spell_block:   21995300,   // use `make deploy-info tx=<deployment-tx>` to obtain the block number
             previous_spells:        prevSpells, // older spells to ensure are executed first
             office_hours_enabled:   true,       // true if officehours is expected to be enabled in the spell

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -106,9 +106,9 @@ contract Config {
         // Values for spell-specific parameters
         //
         spellValues = SpellValues({
-            deployed_spell:         address(0x01cEBd4B43F3b4b03fd4E2a2c8ccc2303D4c4A9D), // populate with deployed spell if deployed
-            deployed_spell_created: 1741354835, // use `make deploy-info tx=<deployment-tx>` to obtain the timestamp
-            deployed_spell_block:   21995361,   // use `make deploy-info tx=<deployment-tx>` to obtain the block number
+            deployed_spell:         address(0), // populate with deployed spell if deployed
+            deployed_spell_created: 0, // use `make deploy-info tx=<deployment-tx>` to obtain the timestamp
+            deployed_spell_block:   21995300,   // use `make deploy-info tx=<deployment-tx>` to obtain the block number
             previous_spells:        prevSpells, // older spells to ensure are executed first
             office_hours_enabled:   true,       // true if officehours is expected to be enabled in the spell
             expiration_threshold:   30 days     // Amount of time before spell expires


### PR DESCRIPTION
Adds new functions `_fixChronicleStaleness` that overwrite the `pokeData.age` and `opPokeData.age` values in the chronicle oracles being used by Aggor. This prevents the oracle being considered "stale" after warping ahead to cast a spell during `_scheduleWaitAndCast`.

These functions were added in DssSpell.t.base.sol, feel free to move them wherever you see fit.

To reproduce the issue and test the fix:
1. Run `make test match=test_chronicleStalenessFix block=21995300`
2. Comment out `_fixChronicleStaleness();` line in `test_chronicleStalenessFix`
3. Run `make test match=test_chronicleStalenessFix block=21995300` again
4. See original failure