### PR TITLE
Fix: `cast-on-tenderly` BAD_REQUEST error

### DIFF
--- a/scripts/cast-on-tenderly/index.js
+++ b/scripts/cast-on-tenderly/index.js
@@ -1,47 +1,34 @@
-import "dotenv/config";
-import axios from "axios";
-import { Contract, ethers, utils } from "ethers";
-import { randomUUID } from "crypto";
+import 'dotenv/config';
+import axios from 'axios';
+import { Contract, ethers, utils } from 'ethers';
+import { randomUUID } from 'crypto';
 
-const NETWORK_ID = "1";
-const CHAINLOG_ADDRESS = "0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F";
+const NETWORK_ID = '1';
+const CHAINLOG_ADDRESS = '0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F';
 const CHIEF_HAT_SLOT = 12;
 const DEFAULT_TRANSACTION_PARAMETERS = { gasLimit: 1_000_000_000 };
 
 // check env vars
-const REQUIRED_ENV_VARS = [
-    "ETH_RPC_URL",
-    "TENDERLY_USER",
-    "TENDERLY_PROJECT",
-    "TENDERLY_ACCESS_KEY",
-];
-if (REQUIRED_ENV_VARS.some((varName) => !process.env[varName])) {
-    throw new Error(
-        `Please provide all required env variables: ${REQUIRED_ENV_VARS.join(
-            ", "
-        )}`
-    );
+const REQUIRED_ENV_VARS = ['ETH_RPC_URL', 'TENDERLY_USER', 'TENDERLY_PROJECT', 'TENDERLY_ACCESS_KEY'];
+if (REQUIRED_ENV_VARS.some(varName => !process.env[varName])) {
+    throw new Error(`Please provide all required env variables: ${REQUIRED_ENV_VARS.join(', ')}`);
 }
 
 // check process arguments
 const SPELL_ADDRESS = process.argv[2];
 if (!SPELL_ADDRESS) {
-    throw new Error(
-        "Please provide address of the spell, e.g.: `node index.js 0x...`"
-    );
+    throw new Error('Please provide address of the spell, e.g.: `node index.js 0x...`');
 }
 
 const getSpellName = async function (spellAddress) {
-    const provider = new ethers.providers.JsonRpcProvider(
-        process.env.ETH_RPC_URL
-    );
+    const provider = new ethers.providers.JsonRpcProvider(process.env.ETH_RPC_URL);
     const spell = new Contract(
         spellAddress,
-        ["function description() external view returns (string memory)"],
+        ['function description() external view returns (string memory)'],
         provider
     );
     const description = await spell.description();
-    return description.split("|")[0].trim();
+    return description.split('|')[0].trim();
 };
 
 const makeTenderlyApiRequest = async function ({ method, path, body }) {
@@ -49,107 +36,103 @@ const makeTenderlyApiRequest = async function ({ method, path, body }) {
     try {
         return await axios[method](`${API_BASE}${path}`, body, {
             headers: {
-                "content-type": "application/json",
-                accept: "application/json, text/plain, */*",
-                "X-Access-Key": process.env.TENDERLY_ACCESS_KEY,
+                'content-type': 'application/json',
+                accept: 'application/json, text/plain, */*',
+                'X-Access-Key': process.env.TENDERLY_ACCESS_KEY,
             },
         });
     } catch (error) {
-        console.error("makeTenderlyApiRequest error", error.response);
+        console.error('makeTenderlyApiRequest error', error.response);
         throw new Error(`tenderly request failed with: ${error.code}`);
     }
 };
 
 const createTenderlyTestnet = async function (spellName) {
-    const slug = `${spellName
-        .replace(/\s+/g, "-")
-        .toLowerCase()}-${randomUUID()}`;
+    const slug = `${spellName.replace(/\s+/g, '-').toLowerCase()}-${randomUUID()}`;
     const response = await makeTenderlyApiRequest({
-        method: "post",
-        path: "/testnet/container",
+        method: 'post',
+        path: '/testnet/container',
         body: {
             slug,
             displayName: spellName,
             description: spellName,
             networkConfig: {
                 networkId: NETWORK_ID,
-                blockNumber: "latest",
+                blockNumber: 'latest',
+                baseFeePerGas: '1',
                 chainConfig: {
                     chainId: NETWORK_ID,
                 },
             },
+            explorerPage: 'DISABLED',
             syncState: true,
-            explorerConfig: {
-                enabled: true,
-                verificationVisibility: "src",
-            },
         },
     });
-    const testnetId = response.data.container?.id;
-    const endpoints =
-        response.data.container?.connectivityConfig?.endpoints ?? [];
-
-    const rpcEndpointAdmin = endpoints.find(
-        (endpoint) =>
-            /^https?:\/\//i.test(endpoint.uri) && endpoint.private == true
+    const testnetId = response.data.container.id;
+    const rpcEndpointPrivate = response.data.container.connectivityConfig.endpoints.find(
+        endpoint => endpoint.private === true
     );
-    if (!rpcEndpointAdmin) {
-        throw new Error("Failed to find admin rpc endpoint");
-    }
-
-    const rpcEndpointPublic = endpoints.find(
-        (endpoint) =>
-            /^https?:\/\//i.test(endpoint.uri) && endpoint.private == false
-    );
-    if (!rpcEndpointPublic) {
-        throw new Error("Failed to find public rpc endpoint");
-    }
-
+    console.info(`tenderly testnet "${testnetId}" is created`);
     return {
         testnetId,
-        rpcUrlAdmin: rpcEndpointAdmin.uri,
-        rpcUrlPublic: rpcEndpointPublic.uri,
-        explorerUrlPublic: `https://dashboard.tenderly.co/explorer/vnet/${rpcEndpointPublic.id}`,
+        rpcUrlPrivate: rpcEndpointPrivate.uri,
     };
 };
 
+const publishTenderlyTestnet = async function (testnetId) {
+    console.info(`making tenderly testnet "${testnetId}" public...`);
+    const response = await makeTenderlyApiRequest({
+        method: 'put',
+        path: `/testnet/container/${testnetId}`,
+        body: {
+            explorerConfig: {
+                enabled: true,
+            },
+        },
+    });
+    if (response.data?.container?.explorer_page !== 'ENABLED') {
+        throw new Error('failed to publish testnet');
+    }
+    console.info(`tenderly testnet is now public and discoverable`);
+    const rpcEndpointPublic = response.data.container.connectivityConfig.endpoints.find(
+        endpoint => endpoint.private === false
+    );
+    const explorerUrlPublic = `https://dashboard.tenderly.co/explorer/vnet/${rpcEndpointPublic.id}`;
+    console.info(`public explorer url: ${explorerUrlPublic}`);
+    return { rpcUrlPrivate: rpcEndpointPublic.uri, explorerUrlPublic };
+};
+
 const giveTheHatToSpell = async function (spellAddress, provider) {
-    console.info("fetching the chief address from chainlog...");
+    console.info('fetching the chief address from chainlog...');
     const chainlog = new Contract(
         CHAINLOG_ADDRESS,
-        ["function getAddress(bytes32) external view returns (address)"],
+        ['function getAddress(bytes32) external view returns (address)'],
         provider.getSigner()
     );
-    const chiefAddress = await chainlog.getAddress(
-        ethers.utils.formatBytes32String("MCD_ADM")
-    );
+    const chiefAddress = await chainlog.getAddress(ethers.utils.formatBytes32String('MCD_ADM'));
 
-    console.info("overwriting the hat...");
-    await provider.send("tenderly_setStorageAt", [
+    console.info('overwriting the hat...');
+    await provider.send('tenderly_setStorageAt', [
         chiefAddress,
         ethers.utils.hexZeroPad(ethers.utils.hexValue(CHIEF_HAT_SLOT), 32),
         ethers.utils.hexZeroPad(spellAddress, 32),
     ]);
 
-    console.info("checking the hat...");
-    const chief = new Contract(
-        chiefAddress,
-        ["function hat() external view returns (address)"],
-        provider.getSigner()
-    );
+    console.info('checking the hat...');
+    const chief = new Contract(chiefAddress, ['function hat() external view returns (address)'], provider.getSigner());
     const hatAddress = await chief.hat();
     if (hatAddress !== spellAddress) {
-        throw new Error("spell does not have the hat");
+        throw new Error('spell does not have the hat');
     }
-    console.info("spell have the hat...");
+    console.info('spell have the hat...');
 };
 
-const fixChronicleStaleness = async function (provider) {
+const fixChronicleStaleness = async function(provider) {
     async function _fixChronicleStaleness(oracleAddress) {
         const slot = ethers.utils.hexZeroPad(ethers.utils.hexValue(4), 32); // the slot of Chronicle `_pokeData` is 4
         const slotData = await provider.getStorageAt(oracleAddress, slot);
 
-        const packedTypes = ["uint32 age", "uint128 price"];
+        const packedTypes = ['uint32 age', 'uint128 price'];
         const abiCoder = new ethers.utils.AbiCoder();
         abiCoder._getWordSize = () => 16;
 
@@ -159,81 +142,70 @@ const fixChronicleStaleness = async function (provider) {
         // Extend age by a 30 days margin
         const age = BigInt(Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60);
 
-        await provider.send("tenderly_setStorageAt", [
+        await provider.send('tenderly_setStorageAt', [
             oracleAddress,
             slot,
             abiCoder.encode(packedTypes, [age, price]),
         ]);
     }
 
-    await _fixChronicleStaleness("0x24C392CDbF32Cf911B258981a66d5541d85269ce"); // Chronicle_BTC_USD_3
-    await _fixChronicleStaleness("0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E"); // Chronicle_ETH_USD_3
-};
+    await _fixChronicleStaleness('0x24C392CDbF32Cf911B258981a66d5541d85269ce'); // Chronicle_BTC_USD_3
+    await _fixChronicleStaleness('0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E'); // Chronicle_ETH_USD_3
+}
 
-const scheduleWarpAndCastSpell = async function (spellAddress, provider) {
+const sheduleWarpAndCastSpell = async function (spellAddress, provider) {
     const spell = new Contract(
         spellAddress,
         [
-            "function schedule() external",
-            "function cast() external",
-            "function nextCastTime() external view returns (uint256)",
+            'function schedule() external',
+            'function cast() external',
+            'function nextCastTime() external view returns (uint256)',
         ],
         provider.getSigner()
     );
 
-    console.info("scheduling the spell...");
+    console.info('scheduling the spell...');
     try {
         const scheduleTx = await spell.schedule(DEFAULT_TRANSACTION_PARAMETERS);
         await scheduleTx.wait();
     } catch (error) {
-        console.warn("scheduling failed", error);
+        console.warn('scheduling failed', error);
     }
 
-    console.info("fetching timestamp when the spell will be castable...");
+    console.info('fetching timestamp when the spell will be castable...');
     const nextCastTime = await spell.nextCastTime();
-    console.info(
-        `nextCastTime is "${nextCastTime}"`,
-        new Date(nextCastTime.toNumber() * 1000)
-    );
+    console.info(`nextCastTime is "${nextCastTime}"`, new Date(nextCastTime.toNumber() * 1000));
 
     console.info(`warping the time to "${nextCastTime}"...`);
-    await provider.send("evm_setNextBlockTimestamp", [
-        ethers.utils.hexValue(nextCastTime),
-    ]);
+    await provider.send('evm_setNextBlockTimestamp', [ethers.utils.hexValue(nextCastTime)]);
 
-    console.info("casting spell...");
+    console.info('casting spell...');
     try {
         const castTx = await spell.cast(DEFAULT_TRANSACTION_PARAMETERS);
         await castTx.wait();
-        console.info("successfully casted");
+        console.info('successfully casted');
     } catch (error) {
-        console.error("casting failed", error);
+        console.error('casting failed', error);
     }
 };
 
 const castOnTenderly = async function (spellAddress) {
     const spellName = await getSpellName(spellAddress);
-    console.info(
-        `preparing to cast spell "${spellAddress}" with name "${spellName}"...`
-    );
+    console.info(`preparing to cast spell "${spellAddress}" with name "${spellName}"...`);
 
-    const { testnetId, rpcUrlAdmin, rpcUrlPublic, explorerUrlPublic } =
-        await createTenderlyTestnet(spellName);
+    const { testnetId, rpcUrlPrivate } = await createTenderlyTestnet(spellName);
 
-    console.info(`Testnet ID: ${testnetId}`);
-    console.info(`Admin RPC: ${rpcUrlAdmin}`);
-    console.info(`Public RPC: ${rpcUrlPublic}`);
-    console.info(`Explorer URL: ${explorerUrlPublic}`);
-
-    const provider = new ethers.providers.JsonRpcProvider(rpcUrlAdmin);
+    const provider = new ethers.providers.JsonRpcProvider(rpcUrlPrivate);
 
     // Temporary fix to the reverts of the Spark spells interacting with Aggor oracles, due to the cast time manipulation
     // Example revert: https://dashboard.tenderly.co/explorer/vnet/eb97d953-4642-4778-938e-d70ee25e3f58/tx/0xe427414d07c28b64c076e809983cfdee3bfd680866ebc7c40349700f4a6160bd?trace=0.5.5.1.62.1.2.0.2.2.0.2.2
-    await fixChronicleStaleness(provider);
+    await fixChronicleStaleness(provider)
 
     await giveTheHatToSpell(spellAddress, provider);
 
-    await scheduleWarpAndCastSpell(spellAddress, provider);
+    await sheduleWarpAndCastSpell(spellAddress, provider);
+
+    await publishTenderlyTestnet(testnetId);
 };
 
 castOnTenderly(utils.getAddress(SPELL_ADDRESS));

--- a/scripts/cast-on-tenderly/index.js
+++ b/scripts/cast-on-tenderly/index.js
@@ -102,7 +102,12 @@ const publishTenderlyTestnet = async function (testnetId) {
             },
         },
     });
-    if (response.data.container?.explorer_page !== 'ENABLED') {
+    // Note: apparently the response schema keeps changing, so the following conditions represent the ones that have been observed.
+    if (
+        response.data.container?.explorerConfig?.enabled !== true &&
+        response.data.container?.explorer_config?.enabled !== true &&
+        response.data.container?.explorer_page !== 'ENABLED'
+    ) {
         throw new Error('Failed to publish testnet');
     }
 

--- a/scripts/cast-on-tenderly/index.js
+++ b/scripts/cast-on-tenderly/index.js
@@ -96,7 +96,7 @@ const publishTenderlyTestnet = async function (testnetId) {
         method: 'put',
         path: `/testnet/container/${testnetId}`,
         body: {
-            explorerConfig:{
+            explorerConfig: {
                 enabled: true,
                 verificationVisibility: "src"
             },

--- a/scripts/cast-on-tenderly/index.js
+++ b/scripts/cast-on-tenderly/index.js
@@ -79,14 +79,14 @@ const createTenderlyTestnet = async function (spellName) {
     const endpoints = response.data.container?.connectivityConfig?.endpoints ?? [];
 
     const rpcEndpointAdmin = endpoints.find(
-        endpoint => /https:\/\//i.test(endpoint.uri) && endpoint.private === true
+        endpoint => endpoint.uri?.startsWith('https://') && endpoint.private === true
     );
     if (!rpcEndpointAdmin) {
         throw new Error('Failed to obtain the admin RPC endpoint');
     }
 
     const rpcEndpointPublic = endpoints.find(
-        endpoint => /https:\/\//i.test(endpoint.uri) && endpoint.private === false
+        endpoint => endpoint.uri?.startsWith('https://') && endpoint.private === false
     );
     if (!rpcEndpointPublic) {
         throw new Error('Failed to obtain the public RPC endpoint');

--- a/scripts/cast-on-tenderly/index.js
+++ b/scripts/cast-on-tenderly/index.js
@@ -1,34 +1,47 @@
-import 'dotenv/config';
-import axios from 'axios';
-import { Contract, ethers, utils } from 'ethers';
-import { randomUUID } from 'crypto';
+import "dotenv/config";
+import axios from "axios";
+import { Contract, ethers, utils } from "ethers";
+import { randomUUID } from "crypto";
 
-const NETWORK_ID = '1';
-const CHAINLOG_ADDRESS = '0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F';
+const NETWORK_ID = "1";
+const CHAINLOG_ADDRESS = "0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F";
 const CHIEF_HAT_SLOT = 12;
 const DEFAULT_TRANSACTION_PARAMETERS = { gasLimit: 1_000_000_000 };
 
 // check env vars
-const REQUIRED_ENV_VARS = ['ETH_RPC_URL', 'TENDERLY_USER', 'TENDERLY_PROJECT', 'TENDERLY_ACCESS_KEY'];
-if (REQUIRED_ENV_VARS.some(varName => !process.env[varName])) {
-    throw new Error(`Please provide all required env variables: ${REQUIRED_ENV_VARS.join(', ')}`);
+const REQUIRED_ENV_VARS = [
+    "ETH_RPC_URL",
+    "TENDERLY_USER",
+    "TENDERLY_PROJECT",
+    "TENDERLY_ACCESS_KEY",
+];
+if (REQUIRED_ENV_VARS.some((varName) => !process.env[varName])) {
+    throw new Error(
+        `Please provide all required env variables: ${REQUIRED_ENV_VARS.join(
+            ", "
+        )}`
+    );
 }
 
 // check process arguments
 const SPELL_ADDRESS = process.argv[2];
 if (!SPELL_ADDRESS) {
-    throw new Error('Please provide address of the spell, e.g.: `node index.js 0x...`');
+    throw new Error(
+        "Please provide address of the spell, e.g.: `node index.js 0x...`"
+    );
 }
 
 const getSpellName = async function (spellAddress) {
-    const provider = new ethers.providers.JsonRpcProvider(process.env.ETH_RPC_URL);
+    const provider = new ethers.providers.JsonRpcProvider(
+        process.env.ETH_RPC_URL
+    );
     const spell = new Contract(
         spellAddress,
-        ['function description() external view returns (string memory)'],
+        ["function description() external view returns (string memory)"],
         provider
     );
     const description = await spell.description();
-    return description.split('|')[0].trim();
+    return description.split("|")[0].trim();
 };
 
 const makeTenderlyApiRequest = async function ({ method, path, body }) {
@@ -36,103 +49,107 @@ const makeTenderlyApiRequest = async function ({ method, path, body }) {
     try {
         return await axios[method](`${API_BASE}${path}`, body, {
             headers: {
-                'content-type': 'application/json',
-                accept: 'application/json, text/plain, */*',
-                'X-Access-Key': process.env.TENDERLY_ACCESS_KEY,
+                "content-type": "application/json",
+                accept: "application/json, text/plain, */*",
+                "X-Access-Key": process.env.TENDERLY_ACCESS_KEY,
             },
         });
     } catch (error) {
-        console.error('makeTenderlyApiRequest error', error.response);
+        console.error("makeTenderlyApiRequest error", error.response);
         throw new Error(`tenderly request failed with: ${error.code}`);
     }
 };
 
 const createTenderlyTestnet = async function (spellName) {
-    const slug = `${spellName.replace(/\s+/g, '-').toLowerCase()}-${randomUUID()}`;
+    const slug = `${spellName
+        .replace(/\s+/g, "-")
+        .toLowerCase()}-${randomUUID()}`;
     const response = await makeTenderlyApiRequest({
-        method: 'post',
-        path: '/testnet/container',
+        method: "post",
+        path: "/testnet/container",
         body: {
             slug,
             displayName: spellName,
             description: spellName,
             networkConfig: {
                 networkId: NETWORK_ID,
-                blockNumber: 'latest',
-                baseFeePerGas: '1',
+                blockNumber: "latest",
                 chainConfig: {
                     chainId: NETWORK_ID,
                 },
             },
-            explorerPage: 'DISABLED',
             syncState: true,
-        },
-    });
-    const testnetId = response.data.container.id;
-    const rpcEndpointPrivate = response.data.container.connectivityConfig.endpoints.find(
-        endpoint => endpoint.private === true
-    );
-    console.info(`tenderly testnet "${testnetId}" is created`);
-    return {
-        testnetId,
-        rpcUrlPrivate: rpcEndpointPrivate.uri,
-    };
-};
-
-const publishTenderlyTestnet = async function (testnetId) {
-    console.info(`making tenderly testnet "${testnetId}" public...`);
-    const response = await makeTenderlyApiRequest({
-        method: 'put',
-        path: `/testnet/container/${testnetId}`,
-        body: {
             explorerConfig: {
                 enabled: true,
+                verificationVisibility: "src",
             },
         },
     });
-    if (response.data?.container?.explorer_page !== 'ENABLED') {
-        throw new Error('failed to publish testnet');
-    }
-    console.info(`tenderly testnet is now public and discoverable`);
-    const rpcEndpointPublic = response.data.container.connectivityConfig.endpoints.find(
-        endpoint => endpoint.private === false
+    const testnetId = response.data.container?.id;
+    const endpoints =
+        response.data.container?.connectivityConfig?.endpoints ?? [];
+
+    const rpcEndpointAdmin = endpoints.find(
+        (endpoint) =>
+            /^https?:\/\//i.test(endpoint.uri) && endpoint.private == true
     );
-    const explorerUrlPublic = `https://dashboard.tenderly.co/explorer/vnet/${rpcEndpointPublic.id}`;
-    console.info(`public explorer url: ${explorerUrlPublic}`);
-    return { rpcUrlPrivate: rpcEndpointPublic.uri, explorerUrlPublic };
+    if (!rpcEndpointAdmin) {
+        throw new Error("Failed to find admin rpc endpoint");
+    }
+
+    const rpcEndpointPublic = endpoints.find(
+        (endpoint) =>
+            /^https?:\/\//i.test(endpoint.uri) && endpoint.private == false
+    );
+    if (!rpcEndpointPublic) {
+        throw new Error("Failed to find public rpc endpoint");
+    }
+
+    return {
+        testnetId,
+        rpcUrlAdmin: rpcEndpointAdmin.uri,
+        rpcUrlPublic: rpcEndpointPublic.uri,
+        explorerUrlPublic: `https://dashboard.tenderly.co/explorer/vnet/${rpcEndpointPublic.id}`,
+    };
 };
 
 const giveTheHatToSpell = async function (spellAddress, provider) {
-    console.info('fetching the chief address from chainlog...');
+    console.info("fetching the chief address from chainlog...");
     const chainlog = new Contract(
         CHAINLOG_ADDRESS,
-        ['function getAddress(bytes32) external view returns (address)'],
+        ["function getAddress(bytes32) external view returns (address)"],
         provider.getSigner()
     );
-    const chiefAddress = await chainlog.getAddress(ethers.utils.formatBytes32String('MCD_ADM'));
+    const chiefAddress = await chainlog.getAddress(
+        ethers.utils.formatBytes32String("MCD_ADM")
+    );
 
-    console.info('overwriting the hat...');
-    await provider.send('tenderly_setStorageAt', [
+    console.info("overwriting the hat...");
+    await provider.send("tenderly_setStorageAt", [
         chiefAddress,
         ethers.utils.hexZeroPad(ethers.utils.hexValue(CHIEF_HAT_SLOT), 32),
         ethers.utils.hexZeroPad(spellAddress, 32),
     ]);
 
-    console.info('checking the hat...');
-    const chief = new Contract(chiefAddress, ['function hat() external view returns (address)'], provider.getSigner());
+    console.info("checking the hat...");
+    const chief = new Contract(
+        chiefAddress,
+        ["function hat() external view returns (address)"],
+        provider.getSigner()
+    );
     const hatAddress = await chief.hat();
     if (hatAddress !== spellAddress) {
-        throw new Error('spell does not have the hat');
+        throw new Error("spell does not have the hat");
     }
-    console.info('spell have the hat...');
+    console.info("spell have the hat...");
 };
 
-const fixChronicleStaleness = async function(provider) {
+const fixChronicleStaleness = async function (provider) {
     async function _fixChronicleStaleness(oracleAddress) {
         const slot = ethers.utils.hexZeroPad(ethers.utils.hexValue(4), 32); // the slot of Chronicle `_pokeData` is 4
         const slotData = await provider.getStorageAt(oracleAddress, slot);
 
-        const packedTypes = ['uint32 age', 'uint128 price'];
+        const packedTypes = ["uint32 age", "uint128 price"];
         const abiCoder = new ethers.utils.AbiCoder();
         abiCoder._getWordSize = () => 16;
 
@@ -142,70 +159,81 @@ const fixChronicleStaleness = async function(provider) {
         // Extend age by a 30 days margin
         const age = BigInt(Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60);
 
-        await provider.send('tenderly_setStorageAt', [
+        await provider.send("tenderly_setStorageAt", [
             oracleAddress,
             slot,
             abiCoder.encode(packedTypes, [age, price]),
         ]);
     }
 
-    await _fixChronicleStaleness('0x24C392CDbF32Cf911B258981a66d5541d85269ce'); // Chronicle_BTC_USD_3
-    await _fixChronicleStaleness('0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E'); // Chronicle_ETH_USD_3
-}
+    await _fixChronicleStaleness("0x24C392CDbF32Cf911B258981a66d5541d85269ce"); // Chronicle_BTC_USD_3
+    await _fixChronicleStaleness("0x46ef0071b1E2fF6B42d36e5A177EA43Ae5917f4E"); // Chronicle_ETH_USD_3
+};
 
-const sheduleWarpAndCastSpell = async function (spellAddress, provider) {
+const scheduleWarpAndCastSpell = async function (spellAddress, provider) {
     const spell = new Contract(
         spellAddress,
         [
-            'function schedule() external',
-            'function cast() external',
-            'function nextCastTime() external view returns (uint256)',
+            "function schedule() external",
+            "function cast() external",
+            "function nextCastTime() external view returns (uint256)",
         ],
         provider.getSigner()
     );
 
-    console.info('scheduling the spell...');
+    console.info("scheduling the spell...");
     try {
         const scheduleTx = await spell.schedule(DEFAULT_TRANSACTION_PARAMETERS);
         await scheduleTx.wait();
     } catch (error) {
-        console.warn('scheduling failed', error);
+        console.warn("scheduling failed", error);
     }
 
-    console.info('fetching timestamp when the spell will be castable...');
+    console.info("fetching timestamp when the spell will be castable...");
     const nextCastTime = await spell.nextCastTime();
-    console.info(`nextCastTime is "${nextCastTime}"`, new Date(nextCastTime.toNumber() * 1000));
+    console.info(
+        `nextCastTime is "${nextCastTime}"`,
+        new Date(nextCastTime.toNumber() * 1000)
+    );
 
     console.info(`warping the time to "${nextCastTime}"...`);
-    await provider.send('evm_setNextBlockTimestamp', [ethers.utils.hexValue(nextCastTime)]);
+    await provider.send("evm_setNextBlockTimestamp", [
+        ethers.utils.hexValue(nextCastTime),
+    ]);
 
-    console.info('casting spell...');
+    console.info("casting spell...");
     try {
         const castTx = await spell.cast(DEFAULT_TRANSACTION_PARAMETERS);
         await castTx.wait();
-        console.info('successfully casted');
+        console.info("successfully casted");
     } catch (error) {
-        console.error('casting failed', error);
+        console.error("casting failed", error);
     }
 };
 
 const castOnTenderly = async function (spellAddress) {
     const spellName = await getSpellName(spellAddress);
-    console.info(`preparing to cast spell "${spellAddress}" with name "${spellName}"...`);
+    console.info(
+        `preparing to cast spell "${spellAddress}" with name "${spellName}"...`
+    );
 
-    const { testnetId, rpcUrlPrivate } = await createTenderlyTestnet(spellName);
+    const { testnetId, rpcUrlAdmin, rpcUrlPublic, explorerUrlPublic } =
+        await createTenderlyTestnet(spellName);
 
-    const provider = new ethers.providers.JsonRpcProvider(rpcUrlPrivate);
+    console.info(`Testnet ID: ${testnetId}`);
+    console.info(`Admin RPC: ${rpcUrlAdmin}`);
+    console.info(`Public RPC: ${rpcUrlPublic}`);
+    console.info(`Explorer URL: ${explorerUrlPublic}`);
+
+    const provider = new ethers.providers.JsonRpcProvider(rpcUrlAdmin);
 
     // Temporary fix to the reverts of the Spark spells interacting with Aggor oracles, due to the cast time manipulation
     // Example revert: https://dashboard.tenderly.co/explorer/vnet/eb97d953-4642-4778-938e-d70ee25e3f58/tx/0xe427414d07c28b64c076e809983cfdee3bfd680866ebc7c40349700f4a6160bd?trace=0.5.5.1.62.1.2.0.2.2.0.2.2
-    await fixChronicleStaleness(provider)
+    await fixChronicleStaleness(provider);
 
     await giveTheHatToSpell(spellAddress, provider);
 
-    await sheduleWarpAndCastSpell(spellAddress, provider);
-
-    await publishTenderlyTestnet(testnetId);
+    await scheduleWarpAndCastSpell(spellAddress, provider);
 };
 
 castOnTenderly(utils.getAddress(SPELL_ADDRESS));


### PR DESCRIPTION
### The issue

Currently, `make cast-on-tenderly ...` is failing with the following error:

```js
makeTenderlyApiRequest error {
  status: 400,
  statusText: 'Bad Request',
  headers: Object [AxiosHeaders] {
    'content-type': 'application/json; charset=utf-8',
    'user-agent': 'axios/1.6.5',
    vary: 'Origin,Origin',
    'x-tdly-limit': '400',
    'x-tdly-remaining': '399',
    'x-tdly-reset-timestamp': '1744034055077',
    date: 'Mon, 07 Apr 2025 13:53:15 GMT',
    'content-length': '121',
    'x-envoy-upstream-service-time': '625',
    'x-ratelimit-limit': '600, 600;w=60',
    'x-ratelimit-remaining': '599',
    'x-ratelimit-reset': '46',
    server: 'envoy',
    via: '1.1 google',
    'alt-svc': 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000'
  },
  config: {
    transitional: {
      silentJSONParsing: true,
      forcedJSONParsing: true,
      clarifyTimeoutError: false
    },
    adapter: [ 'xhr', 'http' ],
    transformRequest: [ [Function: transformRequest] ],
    transformResponse: [ [Function: transformResponse] ],
    timeout: 0,
    xsrfCookieName: 'XSRF-TOKEN',
    xsrfHeaderName: 'X-XSRF-TOKEN',
    maxContentLength: -1,
    maxBodyLength: -1,
    env: { FormData: [Function], Blob: [class Blob] },
    validateStatus: [Function: validateStatus],
    headers: Object [AxiosHeaders] {
      Accept: 'application/json, text/plain, */*',
      'Content-Type': 'application/json',
      'X-Access-Key': 'F2lBegVM-tLISg2MPewsSe3TTKD6ii0-',
      'User-Agent': 'axios/1.6.5',
      'Content-Length': '337',
      'Accept-Encoding': 'gzip, compress, deflate, br'
    },
    method: 'post',
    url: 'https://api.tenderly.co/api/v1/account/dewiz-xyz/project/makerdao/testnet/container',
    data: '{"slug":"2025-04-03-makerdao-executive-spell-df43e632-33dc-4b85-ba31-17c049252011","displayName":"2025-04-03 MakerDAO Executive Spell","description":"2025-04-03 MakerDAO Executive Spell","networkConfig":{"networkId":"1","blockNumber":"latest","baseFeePerGas":"1","chainConfig":{"chainId":"1"}},"explorerPage":"DISABLED","syncState":true}'
  },
```

Apparently the API scheme for testnet creation changed.

The documentation hasn't been super helpful. The current version of the [`docs`](https://docs.tenderly.co/reference/api#/operations/createVnet) seem to point to a newer version, which apparently doesn't work as documented.

My goal here is to mimic the Virtual Testnet creation process in the Tenderly UI. I captured the creation request and tried to match it as close as possible.

One of the things that I noticed was that `connectivityConfig` returns actually 4 URLs, 2 public, 2 private for both HTTPS and WSS. I made the script look specifically for the HTTPS version, as the URLs are meant to be shared. The script only works now coincidentally, as the HTTPS endopints come first in the list, because `Array#find` will stop at the first match.

Other than that, there was a typo in `sheduleCastAndWait`, missing a `c`.

### Solution

- [x] Streamlined the Virtual Testnet creation, making it public from the get-go.
- [x] Added more targeted filtering for endpoint URLs.
- [x] Reorganized some internal logs.
