### PR TITLE
Fix: replace `forge-std` state snapshot methods (Updated PR)

### DIFF
--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -1583,7 +1583,7 @@ contract DssSpellTestBase is Config, DssTest {
             _giveTokens(address(mkr), lockAmt);
             _giveTokens(address(sky), lockAmt * afterSpell.sky_mkr_rate);
         }
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
         // Check locking and freeing Mkr
         {
             uint256 initialEngineBalance = mkr.balanceOf(p.engine);
@@ -1595,7 +1595,7 @@ contract DssSpellTestBase is Config, DssTest {
             engine.free(address(this), 0, address(this), lockAmt);
             uint256 exitFee = lockAmt * p.fee / 100_00;
             assertEq(mkr.balanceOf(address(this)), lockAmt - exitFee, "checkLockstakeIlkIntegration/LockAndFreeMkr/invalid-unlocked-balance");
-            vm.revertTo(snapshot);
+            vm.revertToState(snapshot);
         }
         // Check locking and freeing Sky
         {
@@ -1609,7 +1609,7 @@ contract DssSpellTestBase is Config, DssTest {
             engine.freeSky(address(this), 0, address(this), skyAmt);
             uint256 exitFee = lockAmt * p.fee / 100_00 * afterSpell.sky_mkr_rate;
             assertGe(sky.balanceOf(address(this)), skyAmt - exitFee, "checkLockstakeIlkIntegration/LockAndFreeSky/invalid-unlocked-balance");
-            vm.revertTo(snapshot);
+            vm.revertToState(snapshot);
         }
         // Check drawing and wiping
         {
@@ -1631,7 +1631,7 @@ contract DssSpellTestBase is Config, DssTest {
             usds.approve(address(engine), wipeAmt);
             engine.wipe(address(this), 0, wipeAmt);
             assertEq(usds.balanceOf(address(this)), 0, "checkLockstakeIlkIntegration/DrawAndWipe/invalid-usds-balance-after-wipe");
-            vm.revertTo(snapshot);
+            vm.revertToState(snapshot);
         }
         // Check farming and getting a reward
         {
@@ -1652,13 +1652,13 @@ contract DssSpellTestBase is Config, DssTest {
             uint256 resultAmt = engine.getReward(address(this), 0, p.farm, rewardsUser);
             assertGt(resultAmt, 0, "checkLockstakeIlkIntegration/FarmAndGetReward/no-reward-amt");
             assertGt(GemAbstract(rewardsToken).balanceOf(rewardsUser), 0, "checkLockstakeIlkIntegration/FarmAndGetReward/no-reward-balance");
-            vm.revertTo(snapshot);
+            vm.revertToState(snapshot);
         }
         // Check liquidations
-        _checkLockstakeTake(p, lockAmt, drawAmt, false, false); vm.revertTo(snapshot);
-        _checkLockstakeTake(p, lockAmt, drawAmt, false, true); vm.revertTo(snapshot);
-        _checkLockstakeTake(p, lockAmt, drawAmt, true, false); vm.revertTo(snapshot);
-        _checkLockstakeTake(p, lockAmt, drawAmt, true, true); vm.revertTo(snapshot);
+        _checkLockstakeTake(p, lockAmt, drawAmt, false, false); vm.revertToState(snapshot);
+        _checkLockstakeTake(p, lockAmt, drawAmt, false, true); vm.revertToState(snapshot);
+        _checkLockstakeTake(p, lockAmt, drawAmt, true, false); vm.revertToState(snapshot);
+        _checkLockstakeTake(p, lockAmt, drawAmt, true, true); vm.revertToState(snapshot);
     }
 
     struct Sale {
@@ -2055,7 +2055,7 @@ contract DssSpellTestBase is Config, DssTest {
         dai.approve(address(litePsm), type(uint256).max);
 
         // Scale up `amount` to the correct Gem decimals value (buyGem and sellGem both use Gem decimals for precision)
-        uint256 snapshot = vm.snapshot();
+        uint256 snapshot = vm.snapshotState();
 
         // Sell TOKEN _to_ the PSM for DAI (increases debt)
         {
@@ -2069,7 +2069,7 @@ contract DssSpellTestBase is Config, DssTest {
             assertEq(token.balanceOf(address(this)), 0,          _concat("checkLitePsmIlkIntegration/sellGem-token-balance-", p.ilk));
             assertEq(dai.balanceOf(address(this)),   sellWadOut, _concat("checkLitePsmIlkIntegration/sellGem-dai-balance-",   p.ilk));
 
-            vm.revertTo(snapshot);
+            vm.revertToState(snapshot);
         }
 
         // Sell TOKEN _to_ the PSM for DAI with no fees (increases debt)
@@ -2084,7 +2084,7 @@ contract DssSpellTestBase is Config, DssTest {
             assertEq(token.balanceOf(address(this)), 0,          _concat("checkLitePsmIlkIntegration/sellGemNoFee-token-balance-", p.ilk));
             assertEq(dai.balanceOf(address(this)),   sellWadOut, _concat("checkLitePsmIlkIntegration/sellGemNoFee-dai-balance-",   p.ilk));
 
-            vm.revertTo(snapshot);
+            vm.revertToState(snapshot);
         }
 
         // For `sellGem` we had `amount` TOKENS, so there is no issue calling it
@@ -2105,7 +2105,7 @@ contract DssSpellTestBase is Config, DssTest {
             assertLe(dai.balanceOf(address(this)),   tout,   _concat("checkLitePsmIlkIntegration/buyGem-dai-balance-",   p.ilk));
             assertEq(token.balanceOf(address(this)), buyAmt, _concat("checkLitePsmIlkIntegration/buyGem-token-balance-", p.ilk));
 
-            vm.revertTo(snapshot);
+            vm.revertToState(snapshot);
         }
 
         // Buy TOKEN _from_ the PSM for DAI with no fees (decreases debt)
@@ -2123,7 +2123,7 @@ contract DssSpellTestBase is Config, DssTest {
             assertLe(dai.balanceOf(address(this)),   tout,   _concat("checkLitePsmIlkIntegration/buyGemNoFee-dai-balance-",   p.ilk));
             assertEq(token.balanceOf(address(this)), buyAmt, _concat("checkLitePsmIlkIntegration/buyGemNoFee-token-balance-", p.ilk));
 
-            vm.revertTo(snapshot);
+            vm.revertToState(snapshot);
         }
 
         // ----- LitePsmMom can halt swaps -----
@@ -2709,7 +2709,7 @@ contract DssSpellTestBase is Config, DssTest {
         GemAbstract token = GemAbstract(_token);
 
         {
-            uint256 before = vm.snapshot();
+            uint256 before = vm.snapshotState();
 
             // Check each new stream is payable in the future
             uint256 pbalance = token.balanceOf(_s.usr);
@@ -2724,7 +2724,7 @@ contract DssSpellTestBase is Config, DssTest {
                 _concat(_errPrefix, string("/invalid-received-amount"))
             );
 
-            vm.revertTo(before);
+            vm.revertToState(before);
         }
     }
 
@@ -2921,7 +2921,7 @@ contract DssSpellTestBase is Config, DssTest {
             _vote(address(spell));
             spell.schedule();
 
-            uint256 afterSchedule = vm.snapshot();
+            uint256 afterSchedule = vm.snapshotState();
 
             // Cast in the wrong day
             {
@@ -2938,7 +2938,7 @@ contract DssSpellTestBase is Config, DssTest {
                 spell.cast();
             }
 
-            vm.revertTo(afterSchedule);
+            vm.revertToState(afterSchedule);
 
             // Cast too early in the day
 
@@ -2954,7 +2954,7 @@ contract DssSpellTestBase is Config, DssTest {
                 spell.cast();
             }
 
-            vm.revertTo(afterSchedule);
+            vm.revertToState(afterSchedule);
 
             // Cast too late in the day
 
@@ -3548,7 +3548,7 @@ contract DssSpellTestBase is Config, DssTest {
 
             // Dai -> USDS conversion
             {
-                uint256 before = vm.snapshot();
+                uint256 before = vm.snapshotState();
 
                 uint256 pdaiBalance  = dai.balanceOf(daiHolder);
                 uint256 pusdsBalance = usds.balanceOf(usdsHolder);
@@ -3563,12 +3563,12 @@ contract DssSpellTestBase is Config, DssTest {
                 assertEq(dai.balanceOf(daiHolder),   0,                   "TestError/Dai/bad-dai-to-usds-conversion");
                 assertEq(usds.balanceOf(usdsHolder), expectedUsdsBalance, "TestError/Usds/bad-dai-to-usds-conversion");
 
-                vm.revertTo(before);
+                vm.revertToState(before);
             }
 
             // USDS -> Dai conversion
             {
-                uint256 before = vm.snapshot();
+                uint256 before = vm.snapshotState();
 
                 uint256 pusdsBalance = usds.balanceOf(usdsHolder);
                 uint256 pdaiBalance  = dai.balanceOf(daiHolder);
@@ -3583,7 +3583,7 @@ contract DssSpellTestBase is Config, DssTest {
                 assertEq(usds.balanceOf(usdsHolder), 0,                  "TestError/USDS/bad-usds-to-dai-conversion");
                 assertEq(dai.balanceOf(daiHolder),   expectedDaiBalance, "TestError/Dai/bad-usds-to-dai-conversion");
 
-                vm.revertTo(before);
+                vm.revertToState(before);
             }
         }
 
@@ -3597,7 +3597,7 @@ contract DssSpellTestBase is Config, DssTest {
 
             // MKR -> SKY conversion
             {
-                uint256 before = vm.snapshot();
+                uint256 before = vm.snapshotState();
 
                 uint256 pmkrBalance = gov.balanceOf(mkrHolder);
                 uint256 pskyBalance = sky.balanceOf(skyHolder);
@@ -3612,12 +3612,12 @@ contract DssSpellTestBase is Config, DssTest {
                 assertEq(gov.balanceOf(mkrHolder), 0,                  "TestError/MKR/bad-mkr-to-sky-conversion");
                 assertEq(sky.balanceOf(skyHolder), expectedSkyBalance, "TestError/Sky/bad-mkr-to-sky-conversion");
 
-                vm.revertTo(before);
+                vm.revertToState(before);
             }
 
             // SKY -> MKR conversion
             {
-                uint256 before = vm.snapshot();
+                uint256 before = vm.snapshotState();
 
                 uint256 pskyBalance = sky.balanceOf(skyHolder);
                 uint256 pmkrBalance = gov.balanceOf(mkrHolder);
@@ -3632,7 +3632,7 @@ contract DssSpellTestBase is Config, DssTest {
                 assertEq(sky.balanceOf(skyHolder), 0,                  "TestError/SKY/bad-sky-to-mkr-conversion");
                 assertEq(gov.balanceOf(mkrHolder), expectedMkrBalance, "TestError/Mkr/bad-sky-to-mkr-conversion");
 
-                vm.revertTo(before);
+                vm.revertToState(before);
             }
         }
 

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -1595,7 +1595,7 @@ contract DssSpellTestBase is Config, DssTest {
             engine.free(address(this), 0, address(this), lockAmt);
             uint256 exitFee = lockAmt * p.fee / 100_00;
             assertEq(mkr.balanceOf(address(this)), lockAmt - exitFee, "checkLockstakeIlkIntegration/LockAndFreeMkr/invalid-unlocked-balance");
-            vm.revertToState(snapshot);
+            vm.revertToStateAndDelete(snapshot);
         }
         // Check locking and freeing Sky
         {
@@ -1609,7 +1609,7 @@ contract DssSpellTestBase is Config, DssTest {
             engine.freeSky(address(this), 0, address(this), skyAmt);
             uint256 exitFee = lockAmt * p.fee / 100_00 * afterSpell.sky_mkr_rate;
             assertGe(sky.balanceOf(address(this)), skyAmt - exitFee, "checkLockstakeIlkIntegration/LockAndFreeSky/invalid-unlocked-balance");
-            vm.revertToState(snapshot);
+            vm.revertToStateAndDelete(snapshot);
         }
         // Check drawing and wiping
         {
@@ -1631,7 +1631,7 @@ contract DssSpellTestBase is Config, DssTest {
             usds.approve(address(engine), wipeAmt);
             engine.wipe(address(this), 0, wipeAmt);
             assertEq(usds.balanceOf(address(this)), 0, "checkLockstakeIlkIntegration/DrawAndWipe/invalid-usds-balance-after-wipe");
-            vm.revertToState(snapshot);
+            vm.revertToStateAndDelete(snapshot);
         }
         // Check farming and getting a reward
         {
@@ -1652,13 +1652,13 @@ contract DssSpellTestBase is Config, DssTest {
             uint256 resultAmt = engine.getReward(address(this), 0, p.farm, rewardsUser);
             assertGt(resultAmt, 0, "checkLockstakeIlkIntegration/FarmAndGetReward/no-reward-amt");
             assertGt(GemAbstract(rewardsToken).balanceOf(rewardsUser), 0, "checkLockstakeIlkIntegration/FarmAndGetReward/no-reward-balance");
-            vm.revertToState(snapshot);
+            vm.revertToStateAndDelete(snapshot);
         }
         // Check liquidations
-        _checkLockstakeTake(p, lockAmt, drawAmt, false, false); vm.revertToState(snapshot);
-        _checkLockstakeTake(p, lockAmt, drawAmt, false, true); vm.revertToState(snapshot);
-        _checkLockstakeTake(p, lockAmt, drawAmt, true, false); vm.revertToState(snapshot);
-        _checkLockstakeTake(p, lockAmt, drawAmt, true, true); vm.revertToState(snapshot);
+        _checkLockstakeTake(p, lockAmt, drawAmt, false, false); vm.revertToStateAndDelete(snapshot);
+        _checkLockstakeTake(p, lockAmt, drawAmt, false, true); vm.revertToStateAndDelete(snapshot);
+        _checkLockstakeTake(p, lockAmt, drawAmt, true, false); vm.revertToStateAndDelete(snapshot);
+        _checkLockstakeTake(p, lockAmt, drawAmt, true, true); vm.revertToStateAndDelete(snapshot);
     }
 
     struct Sale {
@@ -2123,7 +2123,7 @@ contract DssSpellTestBase is Config, DssTest {
             assertLe(dai.balanceOf(address(this)),   tout,   _concat("checkLitePsmIlkIntegration/buyGemNoFee-dai-balance-",   p.ilk));
             assertEq(token.balanceOf(address(this)), buyAmt, _concat("checkLitePsmIlkIntegration/buyGemNoFee-token-balance-", p.ilk));
 
-            vm.revertToState(snapshot);
+            vm.revertToStateAndDelete(snapshot);
         }
 
         // ----- LitePsmMom can halt swaps -----
@@ -2724,7 +2724,7 @@ contract DssSpellTestBase is Config, DssTest {
                 _concat(_errPrefix, string("/invalid-received-amount"))
             );
 
-            vm.revertToState(before);
+            vm.revertToStateAndDelete(before);
         }
     }
 
@@ -2938,7 +2938,7 @@ contract DssSpellTestBase is Config, DssTest {
                 spell.cast();
             }
 
-            vm.revertToState(afterSchedule);
+            vm.revertToStateAndDelete(afterSchedule);
 
             // Cast too early in the day
 
@@ -2954,7 +2954,7 @@ contract DssSpellTestBase is Config, DssTest {
                 spell.cast();
             }
 
-            vm.revertToState(afterSchedule);
+            vm.revertToStateAndDelete(afterSchedule);
 
             // Cast too late in the day
 
@@ -3563,7 +3563,7 @@ contract DssSpellTestBase is Config, DssTest {
                 assertEq(dai.balanceOf(daiHolder),   0,                   "TestError/Dai/bad-dai-to-usds-conversion");
                 assertEq(usds.balanceOf(usdsHolder), expectedUsdsBalance, "TestError/Usds/bad-dai-to-usds-conversion");
 
-                vm.revertToState(before);
+                vm.revertToStateAndDelete(before);
             }
 
             // USDS -> Dai conversion
@@ -3583,7 +3583,7 @@ contract DssSpellTestBase is Config, DssTest {
                 assertEq(usds.balanceOf(usdsHolder), 0,                  "TestError/USDS/bad-usds-to-dai-conversion");
                 assertEq(dai.balanceOf(daiHolder),   expectedDaiBalance, "TestError/Dai/bad-usds-to-dai-conversion");
 
-                vm.revertToState(before);
+                vm.revertToStateAndDelete(before);
             }
         }
 
@@ -3612,7 +3612,7 @@ contract DssSpellTestBase is Config, DssTest {
                 assertEq(gov.balanceOf(mkrHolder), 0,                  "TestError/MKR/bad-mkr-to-sky-conversion");
                 assertEq(sky.balanceOf(skyHolder), expectedSkyBalance, "TestError/Sky/bad-mkr-to-sky-conversion");
 
-                vm.revertToState(before);
+                vm.revertToStateAndDelete(before);
             }
 
             // SKY -> MKR conversion
@@ -3632,7 +3632,7 @@ contract DssSpellTestBase is Config, DssTest {
                 assertEq(sky.balanceOf(skyHolder), 0,                  "TestError/SKY/bad-sky-to-mkr-conversion");
                 assertEq(gov.balanceOf(mkrHolder), expectedMkrBalance, "TestError/Mkr/bad-sky-to-mkr-conversion");
 
-                vm.revertToState(before);
+                vm.revertToStateAndDelete(before);
             }
         }
 

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -1595,7 +1595,7 @@ contract DssSpellTestBase is Config, DssTest {
             engine.free(address(this), 0, address(this), lockAmt);
             uint256 exitFee = lockAmt * p.fee / 100_00;
             assertEq(mkr.balanceOf(address(this)), lockAmt - exitFee, "checkLockstakeIlkIntegration/LockAndFreeMkr/invalid-unlocked-balance");
-            vm.revertToStateAndDelete(snapshot);
+            vm.revertToState(snapshot);
         }
         // Check locking and freeing Sky
         {
@@ -1609,7 +1609,7 @@ contract DssSpellTestBase is Config, DssTest {
             engine.freeSky(address(this), 0, address(this), skyAmt);
             uint256 exitFee = lockAmt * p.fee / 100_00 * afterSpell.sky_mkr_rate;
             assertGe(sky.balanceOf(address(this)), skyAmt - exitFee, "checkLockstakeIlkIntegration/LockAndFreeSky/invalid-unlocked-balance");
-            vm.revertToStateAndDelete(snapshot);
+            vm.revertToState(snapshot);
         }
         // Check drawing and wiping
         {
@@ -1631,7 +1631,7 @@ contract DssSpellTestBase is Config, DssTest {
             usds.approve(address(engine), wipeAmt);
             engine.wipe(address(this), 0, wipeAmt);
             assertEq(usds.balanceOf(address(this)), 0, "checkLockstakeIlkIntegration/DrawAndWipe/invalid-usds-balance-after-wipe");
-            vm.revertToStateAndDelete(snapshot);
+            vm.revertToState(snapshot);
         }
         // Check farming and getting a reward
         {
@@ -1652,13 +1652,15 @@ contract DssSpellTestBase is Config, DssTest {
             uint256 resultAmt = engine.getReward(address(this), 0, p.farm, rewardsUser);
             assertGt(resultAmt, 0, "checkLockstakeIlkIntegration/FarmAndGetReward/no-reward-amt");
             assertGt(GemAbstract(rewardsToken).balanceOf(rewardsUser), 0, "checkLockstakeIlkIntegration/FarmAndGetReward/no-reward-balance");
-            vm.revertToStateAndDelete(snapshot);
+            vm.revertToState(snapshot);
         }
         // Check liquidations
-        _checkLockstakeTake(p, lockAmt, drawAmt, false, false); vm.revertToStateAndDelete(snapshot);
-        _checkLockstakeTake(p, lockAmt, drawAmt, false, true); vm.revertToStateAndDelete(snapshot);
-        _checkLockstakeTake(p, lockAmt, drawAmt, true, false); vm.revertToStateAndDelete(snapshot);
-        _checkLockstakeTake(p, lockAmt, drawAmt, true, true); vm.revertToStateAndDelete(snapshot);
+        _checkLockstakeTake(p, lockAmt, drawAmt, false, false); vm.revertToState(snapshot);
+        _checkLockstakeTake(p, lockAmt, drawAmt, false, true); vm.revertToState(snapshot);
+        _checkLockstakeTake(p, lockAmt, drawAmt, true, false); vm.revertToState(snapshot);
+        _checkLockstakeTake(p, lockAmt, drawAmt, true, true); vm.revertToState(snapshot);
+
+        vm.deleteStateSnapshots();
     }
 
     struct Sale {
@@ -2123,8 +2125,9 @@ contract DssSpellTestBase is Config, DssTest {
             assertLe(dai.balanceOf(address(this)),   tout,   _concat("checkLitePsmIlkIntegration/buyGemNoFee-dai-balance-",   p.ilk));
             assertEq(token.balanceOf(address(this)), buyAmt, _concat("checkLitePsmIlkIntegration/buyGemNoFee-token-balance-", p.ilk));
 
-            vm.revertToStateAndDelete(snapshot);
+            vm.revertToState(snapshot);
         }
+        vm.deleteStateSnapshots();
 
         // ----- LitePsmMom can halt swaps -----
 
@@ -2724,8 +2727,10 @@ contract DssSpellTestBase is Config, DssTest {
                 _concat(_errPrefix, string("/invalid-received-amount"))
             );
 
-            vm.revertToStateAndDelete(before);
+            vm.revertToState(before);
         }
+
+        vm.deleteStateSnapshots();
     }
 
     function _getIlkMat(bytes32 _ilk) internal view returns (uint256 mat) {
@@ -2938,7 +2943,7 @@ contract DssSpellTestBase is Config, DssTest {
                 spell.cast();
             }
 
-            vm.revertToStateAndDelete(afterSchedule);
+            vm.revertToState(afterSchedule);
 
             // Cast too early in the day
 
@@ -2954,7 +2959,7 @@ contract DssSpellTestBase is Config, DssTest {
                 spell.cast();
             }
 
-            vm.revertToStateAndDelete(afterSchedule);
+            vm.revertToState(afterSchedule);
 
             // Cast too late in the day
 
@@ -2970,6 +2975,7 @@ contract DssSpellTestBase is Config, DssTest {
                 spell.cast();
             }
 
+            vm.deleteStateSnapshots();
         }
     }
 
@@ -3563,7 +3569,7 @@ contract DssSpellTestBase is Config, DssTest {
                 assertEq(dai.balanceOf(daiHolder),   0,                   "TestError/Dai/bad-dai-to-usds-conversion");
                 assertEq(usds.balanceOf(usdsHolder), expectedUsdsBalance, "TestError/Usds/bad-dai-to-usds-conversion");
 
-                vm.revertToStateAndDelete(before);
+                vm.revertToState(before);
             }
 
             // USDS -> Dai conversion
@@ -3583,7 +3589,7 @@ contract DssSpellTestBase is Config, DssTest {
                 assertEq(usds.balanceOf(usdsHolder), 0,                  "TestError/USDS/bad-usds-to-dai-conversion");
                 assertEq(dai.balanceOf(daiHolder),   expectedDaiBalance, "TestError/Dai/bad-usds-to-dai-conversion");
 
-                vm.revertToStateAndDelete(before);
+                vm.revertToState(before);
             }
         }
 
@@ -3612,7 +3618,7 @@ contract DssSpellTestBase is Config, DssTest {
                 assertEq(gov.balanceOf(mkrHolder), 0,                  "TestError/MKR/bad-mkr-to-sky-conversion");
                 assertEq(sky.balanceOf(skyHolder), expectedSkyBalance, "TestError/Sky/bad-mkr-to-sky-conversion");
 
-                vm.revertToStateAndDelete(before);
+                vm.revertToState(before);
             }
 
             // SKY -> MKR conversion
@@ -3632,7 +3638,7 @@ contract DssSpellTestBase is Config, DssTest {
                 assertEq(sky.balanceOf(skyHolder), 0,                  "TestError/SKY/bad-sky-to-mkr-conversion");
                 assertEq(gov.balanceOf(mkrHolder), expectedMkrBalance, "TestError/Mkr/bad-sky-to-mkr-conversion");
 
-                vm.revertToStateAndDelete(before);
+                vm.revertToState(before);
             }
         }
 
@@ -3667,6 +3673,8 @@ contract DssSpellTestBase is Config, DssTest {
             assertGt(assets, passets,                       "TestError/sUSDS/invalid-redeem-assets");
             assertEq(assets, usds.balanceOf(address(this)), "TestError/sUSDS/invalid-balance-after-redeem");
         }
+
+        vm.deleteStateSnapshots();
     }
 
     function _testSPBEAMTauAndBudValues() internal {

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -611,7 +611,7 @@ contract DssSpellTest is DssSpellTestBase {
 
         // This stream is configured in relative to the spell casting time.
         {
-            uint256 before = vm.snapshot();
+            uint256 before = vm.snapshotState();
             _vote(address(spell));
             spell.schedule();
             vm.warp(spell.nextCastTime());
@@ -629,7 +629,7 @@ contract DssSpellTest is DssSpellTestBase {
                 rxd: 0
             });
 
-            vm.revertTo(before);
+            vm.revertToState(before);
         }
 
         _checkVestSkyMint(streams);

--- a/src/DssSpell.t.sol
+++ b/src/DssSpell.t.sol
@@ -629,7 +629,7 @@ contract DssSpellTest is DssSpellTestBase {
                 rxd: 0
             });
 
-            vm.revertToState(before);
+            vm.revertToStateAndDelete(before);
         }
 
         _checkVestSkyMint(streams);


### PR DESCRIPTION
- **refactor: use `snapshotState()`/`revertToStateAndDelete()`**
- **refactor: use `snapshotState()`/`revertToState.*()`**
- **fix: use `revertToState` and `deleteStateSnapshots()` once in the end of the relevant tests**
