### PR TITLE
Use stable Foundry release in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,17 +7,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
-      - name: Install Dependencies
-        run: git submodule update --init --recursive
+      - name: Show Forge version
+        run: |
+          forge --version
 
-      - name: Run tests
-        run: make test
+      - name: Run Forge tests
+        run: |
+          make test
+        id: test
         env:
           ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}


### PR DESCRIPTION
The current `test.yml` GitHub action was created back when there was no stable release for Foundry.
It explicitly uses the `nightly` tag when installing Foundry.

Against all odds, we didn't have major issues so far, however a recent nightly build most likely introduced a bug, reported [here](https://github.com/foundry-rs/foundry/issues/10574).

This PR fixes the issue by removing the `nightly` tag, leaving the default value (`stable`).
