### PR TITLE
Maintenance: update the hat() storage slot (new chief) on the Tenderly testnet creation scriptfix: update chief storage slot (new chief)

### DIFF
--- a/scripts/cast-on-tenderly/index.js
+++ b/scripts/cast-on-tenderly/index.js
@@ -5,7 +5,7 @@ import { randomUUID } from 'crypto';
 
 const NETWORK_ID = '1';
 const CHAINLOG_ADDRESS = '0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F';
-const CHIEF_HAT_SLOT = 12;
+const CHIEF_HAT_SLOT = 1;
 const DEFAULT_TRANSACTION_PARAMETERS = { gasLimit: 1_000_000_000 };
 
 // check env vars


### PR DESCRIPTION
Updating the Hat storage slot so the Tenderly testnet creation script works with the new chief.

Slot 1 was tested with success on the 2025-05-29 Spell.
