### PR TITLE
Fix cast block command in deploy script

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -105,7 +105,7 @@ print(f"Fetched transaction block: {tx_block}")
 
 # Get deployed contract timestamp
 tx_timestamp = subprocess.run(
-    ["cast", "block", "--field", "timestamp", "--json", tx_block],
+    ["cast", "block", tx_block, "--field", "timestamp"],
     stdout=subprocess.PIPE,
     text=True,
     check=True,


### PR DESCRIPTION
# Description

This PR fixes the error in compiling tests which occurred during deployment of `2025-12-11` and `2026-01-29` spells using the new `deploy.py` script.

The error happens because the command used inside the deploy script
```sh
cast block --field timestamp 23989229
```

in the latest stable foundry version started to produce "unclear" output in the format of:
```
1766575739
23989229 is not a valid block field
```

When https://github.com/sky-ecosystem/spells-mainnet/pull/491 was merged, the `cast block` command had a different interpretation of the last argument which was likely later changed to be considered a part of `--field`, leading to the extra warning being printed to `stdout` and thus resulting in the incorrect substitution of timestamp inside `config.sol` (`23989229` interpreted as part of `--field`).

The modified command as of now is:
```sh
cast block 23989229 --field timestamp
```

where block number argument was made unambiguous and thus producing the correct result of:
```
1765453619
```
