### PR TITLE
Update: lower line_offset by 30M to adjust local/global line gap

### DIFF
--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -1418,8 +1418,6 @@ contract DssSpellTestBase is Config, DssTest {
         // Enforce the global Line also falls between (sum of lines) + offset and (sum of lines) + 2*offset.
         assertLe(sums[0] +     values.line_offset * RAD, vat.Line(), "TestError/vat-Line-2");
         assertGe(sums[0] + 2 * values.line_offset * RAD, vat.Line(), "TestError/vat-Line-3");
-
-        // TODO: have a discussion about how we want to manage the global Line going forward.
     }
 
     function _getOSMPrice(address pip) internal returns (uint256) {

--- a/src/test/config.sol
+++ b/src/test/config.sol
@@ -153,7 +153,7 @@ contract Config {
         //
         // Values for all system configuration changes
         //
-        afterSpell.line_offset            = 700 * MILLION;                                // Offset between the global line against the sum of local lines
+        afterSpell.line_offset            = 670 * MILLION;                                // Offset between the global line against the sum of local lines
         afterSpell.pause_delay            = 24 hours;                                     // In seconds
         afterSpell.vow_wait               = 156 hours;                                    // In seconds
         afterSpell.vow_dump               = 0;                                            // In whole Dai units


### PR DESCRIPTION
Addressing issue #362.

Lower `line_offset` by 30M in the mainnet spells config.
The current gap between global `vat.Line()` and the sum of local ilk lines allows this reduction while preserving `vat-Line-3` check.