### PR TITLE
Strengthen StarGuard deadline test assertions

### DIFF
--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -4252,7 +4252,7 @@ contract DssSpellTestBase is Config, DssTest {
 
         uint256 beforeExpiry = vm.snapshotState();
 
-        vm.warp(deadline - 1);
+        vm.warp(deadline);
         assertTrue(starGuard.prob(), "StarGuard/prob-not-true-before-deadline");
 
         vm.expectEmit(true, false, false, false, address(starGuard));

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -4250,8 +4250,10 @@ contract DssSpellTestBase is Config, DssTest {
         assertGt(deadline, block.timestamp, "StarGuard/deadline-not-in-future");
         assertTrue(starGuard.prob(), "StarGuard/prob-not-true-after-plot");
 
+        // Snapshot the plotted state so the execution and boundary checks do not affect each other.
         uint256 beforeExpiry = vm.snapshotState();
 
+        // Execution must work strictly before expiry.
         vm.warp(deadline - 1);
         assertTrue(starGuard.prob(), "StarGuard/prob-not-true-before-deadline");
 
@@ -4260,10 +4262,12 @@ contract DssSpellTestBase is Config, DssTest {
         address executed = starGuard.exec();
         assertEq(executed, primeAgentSpell, "StarGuard/exec-wrong-target");
 
+        // StarGuard's deadline check is inclusive: block.timestamp <= deadline.
         vm.revertToState(beforeExpiry);
         vm.warp(deadline);
         assertTrue(starGuard.prob(), "StarGuard/prob-not-true-at-deadline");
 
+        // After the inclusive deadline, prob() must flip false.
         vm.revertToState(beforeExpiry);
         vm.warp(deadline + 1);
         assertFalse(starGuard.prob(), "StarGuard/prob-true-after-deadline");

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -4252,13 +4252,17 @@ contract DssSpellTestBase is Config, DssTest {
 
         uint256 beforeExpiry = vm.snapshotState();
 
-        vm.warp(deadline);
+        vm.warp(deadline - 1);
         assertTrue(starGuard.prob(), "StarGuard/prob-not-true-before-deadline");
 
         vm.expectEmit(true, false, false, false, address(starGuard));
         emit Exec(address(primeAgentSpell));
         address executed = starGuard.exec();
         assertEq(executed, primeAgentSpell, "StarGuard/exec-wrong-target");
+
+        vm.revertToState(beforeExpiry);
+        vm.warp(deadline);
+        assertTrue(starGuard.prob(), "StarGuard/prob-not-true-at-deadline");
 
         vm.revertToState(beforeExpiry);
         vm.warp(deadline + 1);

--- a/src/DssSpell.t.base.sol
+++ b/src/DssSpell.t.base.sol
@@ -4247,19 +4247,23 @@ contract DssSpellTestBase is Config, DssTest {
         assertEq(primeAgentSpell, spellAddr, "TestError/PrimeAgentSpell/prime-agent-starguard-spell-not-updated");
         assertEq(primeAgentSpellHash, spellHash, "TestError/PrimeAgentSpell/prime-agent-starguard-spell-hash-mismatch");
 
-        // Try to execute the primeAgentSpell via starGuard before the deadline
-        while (block.timestamp <= deadline) {
-            if (!starGuard.prob()) {
-                skip(1 hours);
-            } else {
-                vm.expectEmit(true, false, false, false, address(starGuard));
-                emit Exec(address(primeAgentSpell));
-                address executed = starGuard.exec();
-                assertEq(executed, primeAgentSpell, "StarGuard/exec-wrong-target");
-                return;
-            }
-        }
-        revert("TestError/PrimeAgentSpell/spell-not-executable-before-deadline");
+        assertGt(deadline, block.timestamp, "StarGuard/deadline-not-in-future");
+        assertTrue(starGuard.prob(), "StarGuard/prob-not-true-after-plot");
+
+        uint256 beforeExpiry = vm.snapshotState();
+
+        vm.warp(deadline - 1);
+        assertTrue(starGuard.prob(), "StarGuard/prob-not-true-before-deadline");
+
+        vm.expectEmit(true, false, false, false, address(starGuard));
+        emit Exec(address(primeAgentSpell));
+        address executed = starGuard.exec();
+        assertEq(executed, primeAgentSpell, "StarGuard/exec-wrong-target");
+
+        vm.revertToState(beforeExpiry);
+        vm.warp(deadline + 1);
+        assertFalse(starGuard.prob(), "StarGuard/prob-true-after-deadline");
+        vm.revertToStateAndDelete(beforeExpiry);
     }
 
     event Drop(address indexed addr);


### PR DESCRIPTION
## Summary
- Strengthen the Prime Agent StarGuard indirect-execution helper to assert `prob()` after plot, at `deadline - 1`, and after expiry.
- Preserve the existing `exec()` verification before the deadline while removing the hourly probing loop.

## Test Plan
- `make test match=testPrimeAgentSpellExecutions`

Fixes #554