### PR TITLE
ci: validate SafeHarbor payloads after Tenderly casts

### DIFF
--- a/.github/workflows/safeharbor.yaml
+++ b/.github/workflows/safeharbor.yaml
@@ -7,12 +7,27 @@ on:
   pull_request:
     paths:
       - "scripts/safeharbor/**"
+  workflow_dispatch:
+    inputs:
+      rpc_url:
+        description: Public RPC URL for the post-cast Tenderly VNet
+        required: true
+        type: string
+      spell_address:
+        description: Address of the spell cast on the VNet
+        required: true
+        type: string
+      explorer_url:
+        description: Public Tenderly explorer URL for the VNet
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   tests:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -23,3 +38,29 @@ jobs:
 
       - name: Run SafeHarbor tests
         run: npm test --prefix scripts/safeharbor -- --run --reporter=verbose
+
+  validate:
+    if: github.event_name == 'workflow_dispatch'
+    name: SafeHarbor post-cast validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      ETH_RPC_URL: ${{ inputs.rpc_url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: npm ci --prefix scripts/safeharbor
+
+      - name: Record simulation details
+        env:
+          SPELL_ADDRESS: ${{ inputs.spell_address }}
+          EXPLORER_URL: ${{ inputs.explorer_url }}
+        run: |
+          echo "### SafeHarbor post-cast validation" >> "$GITHUB_STEP_SUMMARY"
+          printf -- '- Spell: `%s`\n' "$SPELL_ADDRESS" >> "$GITHUB_STEP_SUMMARY"
+          printf -- '- Tenderly VNet: %s\n' "$EXPLORER_URL" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify post-cast SafeHarbor state
+        run: npm --prefix scripts/safeharbor run --silent verify

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ flatten              :; forge flatten src/DssSpell.sol --output out/flat.sol
 diff-deployed-spell  :; ./scripts/diff-deployed-dssspell.sh $(spell)
 check-deployed-spell :; ./scripts/check-deployed-dssspell.sh
 cast-on-tenderly     :; cd ./scripts/cast-on-tenderly/ && npm i && npm start -- $(spell); cd -
+cast-on-tenderly-safeharbor :; cd ./scripts/cast-on-tenderly/ && npm i && npm start -- $(spell) --safeharbor-ci; cd -
 archive-spell        :; ./scripts/archive-dssspell.sh "$(if $(date),$(date),$(shell date +'%Y-%m-%d'))"
 diff-archive-spell   :; ./scripts/diff-archive-dssspell.sh "$(if $(date),$(date),$(shell date +'%Y-%m-%d'))"
 feed                 :; ./scripts/check-oracle-feed.sh $(pip)
@@ -22,3 +23,4 @@ arb-cost             :; ./scripts/get-arb-relay-cost.sh $(spell)
 rates                :; ./scripts/rates.sh $(pct)
 safeharbor-generate  :; cd scripts/safeharbor && npm --silent ci && npm run --silent generate
 safeharbor-inspect   :; cd scripts/safeharbor && npm --silent ci && npm run --silent inspect
+safeharbor-verify    :; cd scripts/safeharbor && npm --silent ci && npm run --silent verify

--- a/scripts/cast-on-tenderly/index.js
+++ b/scripts/cast-on-tenderly/index.js
@@ -2,6 +2,11 @@ import 'dotenv/config';
 import axios from 'axios';
 import { Contract, ethers, utils } from 'ethers';
 import { randomUUID } from 'crypto';
+import {
+    dispatchSafeHarborValidation,
+    prepareSafeHarborDispatch,
+    shouldDispatchSafeHarbor,
+} from './safeharborCI.js';
 
 const NETWORK_ID = '1';
 const CHAINLOG_ADDRESS = '0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F';
@@ -15,7 +20,8 @@ if (REQUIRED_ENV_VARS.some(varName => !process.env[varName])) {
 }
 
 // check process arguments
-const SPELL_ADDRESS = process.argv[2];
+const ARGS = process.argv.slice(2);
+const SPELL_ADDRESS = ARGS[0];
 if (!SPELL_ADDRESS) {
     throw new Error('Please provide address of the spell, e.g.: `node index.js 0x...`');
 }
@@ -204,6 +210,9 @@ const scheduleWarpAndCastSpell = async function (spellAddress, provider) {
 };
 
 const castOnTenderly = async function (spellAddress) {
+    const safeHarborBranch = shouldDispatchSafeHarbor(ARGS)
+        ? prepareSafeHarborDispatch()
+        : null;
     const spellName = await getSpellName(spellAddress);
     console.info(`Preparing to cast spell ${spellAddress} with name "${spellName}"...\n`);
 
@@ -232,6 +241,17 @@ const castOnTenderly = async function (spellAddress) {
         'Public RPC URL': rpcUrlPublic,
         'Public Explorer URL': explorerUrlPublic
     });
+
+    if (safeHarborBranch) {
+        console.info('\nDispatching SafeHarbor post-cast validation...');
+        const runUrl = dispatchSafeHarborValidation({
+            branch: safeHarborBranch,
+            rpcUrlPublic,
+            explorerUrlPublic,
+            spellAddress,
+        });
+        console.info(`SafeHarbor validation dispatched: ${runUrl}`);
+    }
 };
 
 castOnTenderly(utils.getAddress(SPELL_ADDRESS));

--- a/scripts/cast-on-tenderly/package.json
+++ b/scripts/cast-on-tenderly/package.json
@@ -5,7 +5,8 @@
   "description": "A script to execute spell on a fork",
   "main": "index.js",
   "scripts": {
-    "start": "node ."
+    "start": "node .",
+    "test": "node --test"
   },
   "dependencies": {
     "axios": "^1.4.0",

--- a/scripts/cast-on-tenderly/safeharborCI.js
+++ b/scripts/cast-on-tenderly/safeharborCI.js
@@ -1,0 +1,64 @@
+import { execFileSync } from 'node:child_process';
+
+const REPOSITORY = 'sky-ecosystem/spells-mainnet';
+const WORKFLOW = 'safeharbor.yaml';
+
+function runCommand(command, args) {
+    return execFileSync(command, args, { encoding: 'utf8' }).trim();
+}
+
+export function shouldDispatchSafeHarbor(args) {
+    return args.includes('--safeharbor-ci');
+}
+
+export function prepareSafeHarborDispatch(run = runCommand) {
+    const branch = run('git', ['branch', '--show-current']);
+    if (!branch) {
+        throw new Error('SafeHarbor CI requires a named branch');
+    }
+
+    if (run('git', ['status', '--porcelain'])) {
+        throw new Error('SafeHarbor CI worktree must be clean');
+    }
+
+    const remote = run('git', ['config', `branch.${branch}.remote`]);
+    const remoteRef = run('git', ['config', `branch.${branch}.merge`]);
+    if (!remote || !remoteRef) {
+        throw new Error('SafeHarbor CI branch must have an upstream');
+    }
+
+    const head = run('git', ['rev-parse', 'HEAD']);
+    const remoteHead = run('git', [
+        'ls-remote',
+        '--exit-code',
+        remote,
+        remoteRef,
+    ]).split(/\s/)[0];
+    if (head !== remoteHead) {
+        throw new Error('SafeHarbor CI branch must be pushed before casting');
+    }
+
+    run('gh', ['workflow', 'view', WORKFLOW, '--repo', REPOSITORY]);
+    return branch;
+}
+
+export function dispatchSafeHarborValidation(
+    { branch, rpcUrlPublic, explorerUrlPublic, spellAddress },
+    run = runCommand,
+) {
+    return run('gh', [
+        'workflow',
+        'run',
+        WORKFLOW,
+        '--repo',
+        REPOSITORY,
+        '--ref',
+        branch,
+        '--raw-field',
+        `rpc_url=${rpcUrlPublic}`,
+        '--raw-field',
+        `spell_address=${spellAddress}`,
+        '--raw-field',
+        `explorer_url=${explorerUrlPublic}`,
+    ]);
+}

--- a/scripts/cast-on-tenderly/test/safeharborCI.test.js
+++ b/scripts/cast-on-tenderly/test/safeharborCI.test.js
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+    dispatchSafeHarborValidation,
+    prepareSafeHarborDispatch,
+    shouldDispatchSafeHarbor,
+} from '../safeharborCI.js';
+
+describe('SafeHarbor CI dispatch', () => {
+    test('is opt-in', () => {
+        assert.equal(shouldDispatchSafeHarbor(['0x1234']), false);
+        assert.equal(
+            shouldDispatchSafeHarbor(['0x1234', '--safeharbor-ci']),
+            true,
+        );
+    });
+
+    test('accepts a clean branch matching its remote', () => {
+        const calls = [];
+        const run = (command, args) => {
+            calls.push([command, args]);
+            const key = [command, ...args].join(' ');
+            const results = {
+                'git branch --show-current':
+                    'maintenance/safeharbor-live-validation',
+                'git status --porcelain': '',
+                'git config branch.maintenance/safeharbor-live-validation.remote':
+                    'origin',
+                'git config branch.maintenance/safeharbor-live-validation.merge':
+                    'refs/heads/maintenance/safeharbor-live-validation',
+                'git rev-parse HEAD': 'abc123',
+                'git ls-remote --exit-code origin refs/heads/maintenance/safeharbor-live-validation':
+                    'abc123\trefs/heads/maintenance/safeharbor-live-validation',
+                'gh workflow view safeharbor.yaml --repo sky-ecosystem/spells-mainnet':
+                    'SafeHarbor Tests',
+            };
+            return results[key];
+        };
+
+        assert.equal(
+            prepareSafeHarborDispatch(run),
+            'maintenance/safeharbor-live-validation',
+        );
+        assert.ok(calls.some(([command]) => command === 'gh'));
+    });
+
+    test('rejects a dirty worktree', () => {
+        const run = (command, args) => {
+            const key = [command, ...args].join(' ');
+            return {
+                'git branch --show-current':
+                    'maintenance/safeharbor-live-validation',
+                'git status --porcelain':
+                    ' M scripts/cast-on-tenderly/index.js',
+            }[key];
+        };
+
+        assert.throws(
+            () => prepareSafeHarborDispatch(run),
+            /worktree must be clean/,
+        );
+    });
+
+    test('rejects a branch whose HEAD is not on the remote', () => {
+        const run = (command, args) => {
+            const key = [command, ...args].join(' ');
+            return {
+                'git branch --show-current':
+                    'maintenance/safeharbor-live-validation',
+                'git status --porcelain': '',
+                'git config branch.maintenance/safeharbor-live-validation.remote':
+                    'origin',
+                'git config branch.maintenance/safeharbor-live-validation.merge':
+                    'refs/heads/maintenance/safeharbor-live-validation',
+                'git rev-parse HEAD': 'local123',
+                'git ls-remote --exit-code origin refs/heads/maintenance/safeharbor-live-validation':
+                    'remote456\trefs/heads/maintenance/safeharbor-live-validation',
+            }[key];
+        };
+
+        assert.throws(() => prepareSafeHarborDispatch(run), /must be pushed/);
+    });
+
+    test('dispatches the public VNet details on the selected branch', () => {
+        let invocation;
+        const run = (command, args) => {
+            invocation = [command, args];
+            return 'https://github.com/sky-ecosystem/spells-mainnet/actions/runs/1';
+        };
+
+        const runUrl = dispatchSafeHarborValidation(
+            {
+                branch: 'maintenance/safeharbor-live-validation',
+                rpcUrlPublic: 'https://virtual.mainnet.rpc.tenderly.co/public',
+                explorerUrlPublic:
+                    'https://dashboard.tenderly.co/explorer/vnet/public',
+                spellAddress: '0x1000000000000000000000000000000000000001',
+            },
+            run,
+        );
+
+        assert.equal(invocation[0], 'gh');
+        assert.deepEqual(invocation[1], [
+            'workflow',
+            'run',
+            'safeharbor.yaml',
+            '--repo',
+            'sky-ecosystem/spells-mainnet',
+            '--ref',
+            'maintenance/safeharbor-live-validation',
+            '--raw-field',
+            'rpc_url=https://virtual.mainnet.rpc.tenderly.co/public',
+            '--raw-field',
+            'spell_address=0x1000000000000000000000000000000000000001',
+            '--raw-field',
+            'explorer_url=https://dashboard.tenderly.co/explorer/vnet/public',
+        ]);
+        assert.equal(
+            runUrl,
+            'https://github.com/sky-ecosystem/spells-mainnet/actions/runs/1',
+        );
+    });
+});

--- a/scripts/safeharbor/README.md
+++ b/scripts/safeharbor/README.md
@@ -35,9 +35,11 @@ There are a few steps to independently validate that a given agreement can be ad
 1. It has to be deployed via a transaction to known public factory.
 2. The owner of the agreement has to be PauseProxy.
 3. Agreement details (protocol name, agreement URI, contact details and bounty terms) has to match what's described in the Atlas.
-4. The output of `make safeharbor-generate` command, on spells-mainnet repo, has to be "no updates".
+4. The `make safeharbor-verify` command, on spells-mainnet repo, has to pass without updates or validation issues.
 
 If all of these steps are done, the agreement can be adopted by Sky protocol.
+
+For spells that update SafeHarbor, `make cast-on-tenderly-safeharbor spell=<address>` casts the spell on a Tenderly Virtual TestNet and dispatches the post-cast verification workflow. The command requires a clean branch whose current commit has been pushed to its upstream. Ordinary spells should continue to use `make cast-on-tenderly spell=<address>`.
 
 # General Flow of `generatePayload.js`
 
@@ -78,6 +80,12 @@ npm run inspect
 ```
 
 Returns a JSON object containing the individual updates and the solidity snippet.
+
+```bash
+npm run verify
+```
+
+Exits successfully only when the on-chain Agreement matches the source data and no validation issues are found.
 
 In order to obtain machine-readable JSON output of the script, use the following command:
 

--- a/scripts/safeharbor/index.js
+++ b/scripts/safeharbor/index.js
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import { generatePayload } from "./src/generatePayload.js";
+import { verifyPayload } from "./src/verifyPayload.js";
 
 import { createAgreementInstance } from "./src/utils/contractUtils.js";
 
@@ -52,10 +53,17 @@ try {
             console.warn("No updates to generate");
             process.exit(0);
         }
+    } else if (command === "verify") {
+        const result = await generatePayload(agreementContract);
+        verifyPayload(result);
+        console.warn(
+            "SafeHarbor verification passed: no updates or validation issues.",
+        );
+        process.exit(0);
     } else {
         console.error(`Error: Unknown command '${command}'`);
-        console.error("Available commands: generate, inspect");
-        console.error("Usage: npm run generate");
+        console.error("Available commands: generate, inspect, verify");
+        console.error("Usage: npm run <generate|inspect|verify>");
         process.exit(1);
     }
 } catch (error) {

--- a/scripts/safeharbor/src/fetchCSV.js
+++ b/scripts/safeharbor/src/fetchCSV.js
@@ -61,7 +61,10 @@ export async function getNormalizedContractsInScopeFromCSV(url) {
     return normalizeContractsInScope(records);
 }
 
-export async function getChainDetailsFromCSV(url) {
+export async function getChainDetailsFromCSV(
+    url,
+    reportValidationIssue = console.warn,
+) {
     const records = await downloadAndParse(url);
 
     // Normalize chain details data
@@ -77,14 +80,14 @@ export async function getChainDetailsFromCSV(url) {
         if (chainName && chainId && chainAssetRecoveryAddress) {
             // Check for duplicate names - if key already exists in object
             if (caip2ChainId[chainName]) {
-                console.warn(
+                reportValidationIssue(
                     `⚠️  Warning: Duplicate chain name found in CSV: ${chainName} ⚠️`,
                 );
             }
 
             // Check for duplicate chain IDs - if key already exists in object
             if (name[chainId]) {
-                console.warn(
+                reportValidationIssue(
                     `⚠️  Warning: Duplicate chain ID found in CSV: ${chainId} ⚠️`,
                 );
             }

--- a/scripts/safeharbor/src/fetchOnchain.js
+++ b/scripts/safeharbor/src/fetchOnchain.js
@@ -1,10 +1,10 @@
 // Build internal representation from on-chain state
-function normalize(details, chainDetails) {
+function normalize(details, chainDetails, reportValidationIssue) {
     return details.chains.reduce((chains, chain) => {
         const chainName = chainDetails.name[chain.caip2ChainId];
 
         if (!chainName) {
-            console.warn(
+            reportValidationIssue(
                 `\n\n⚠️-----⚠️ \nUnknown chain details in on-chain state: caip2ChainId='${chain.caip2ChainId}'. \nTo either remove or keep this chain, please add the chain details to the chain details tab in the Google Sheet. \n⚠️-----⚠️\n\n`,
             );
             return chains;
@@ -24,7 +24,8 @@ function normalize(details, chainDetails) {
 export async function getNormalizedDataFromOnchainState(
     agreementContract,
     chainDetails,
+    reportValidationIssue = console.warn,
 ) {
     const details = await agreementContract.getDetails();
-    return normalize(details, chainDetails);
+    return normalize(details, chainDetails, reportValidationIssue);
 }

--- a/scripts/safeharbor/src/generatePayload.js
+++ b/scripts/safeharbor/src/generatePayload.js
@@ -24,9 +24,10 @@ import {
  * @function generatePayload
  * @param {Object} agreementContract - The ethers.js agreement contract instance
  * @param {string} agreementContract.address - The address of the agreement contract
- * @returns {Promise<{updates: Array<{function: string, args: Array<any>, calldata: string}>, solidityCode: string}>} Object containing:
+ * @returns {Promise<{updates: Array<{function: string, args: Array<any>, calldata: string}>, solidityCode: string, validationIssues: string[]}>} Object containing:
  *   - updates: Array of update objects with function calls and calldata
  *   - solidityCode: Generated Solidity code for the updates
+ *   - validationIssues: Source or on-chain data issues that make reconciliation incomplete
  * @throws {Error} If any step in the process fails
  *
  * @example
@@ -36,6 +37,12 @@ import {
  */
 export async function generatePayload(agreementContract) {
     try {
+        const validationIssues = [];
+        const reportValidationIssue = (issue) => {
+            validationIssues.push(issue);
+            console.warn(issue);
+        };
+
         // 0. Fetch chain information once at the beginning
         console.warn("Fetching chains details CSV...");
         /**
@@ -44,6 +51,7 @@ export async function generatePayload(agreementContract) {
          */
         const chainDetails = await getChainDetailsFromCSV(
             CHAIN_DETAILS_SHEET_URL,
+            reportValidationIssue,
         );
 
         // 1. Download and parse CSV
@@ -65,6 +73,7 @@ export async function generatePayload(agreementContract) {
         const onChainState = await getNormalizedDataFromOnchainState(
             agreementContract,
             chainDetails,
+            reportValidationIssue,
         );
 
         // 3. Generate updates
@@ -73,12 +82,18 @@ export async function generatePayload(agreementContract) {
          * Array of update objects representing differences between CSV and on-chain state
          * @type {Array<{function: string, args: Array<any>, calldata: string}>}
          */
-        const updates = generateUpdates(onChainState, csvState, chainDetails);
+        const updates = generateUpdates(
+            onChainState,
+            csvState,
+            chainDetails,
+            reportValidationIssue,
+        );
 
         if (updates.length === 0) {
             return {
                 updates: [],
                 solidityCode: "",
+                validationIssues,
             };
         }
 
@@ -92,6 +107,7 @@ export async function generatePayload(agreementContract) {
         return {
             updates,
             solidityCode,
+            validationIssues,
         };
     } catch (error) {
         /**

--- a/scripts/safeharbor/src/generateUpdates.js
+++ b/scripts/safeharbor/src/generateUpdates.js
@@ -102,7 +102,12 @@ function generateAccountUpdates(
     return updates;
 }
 
-function validateRecoveryAddress(onChainState, csvState, chainDetails) {
+function validateRecoveryAddress(
+    onChainState,
+    csvState,
+    chainDetails,
+    reportValidationIssue,
+) {
     const onChainChains = new Set(Object.keys(onChainState));
     const csvChains = new Set(Object.keys(csvState));
 
@@ -121,14 +126,19 @@ function validateRecoveryAddress(onChainState, csvState, chainDetails) {
             onchainRecoveryAddress.toLowerCase() !==
                 csvRecoveryAddress.toLowerCase()
         ) {
-            console.warn(
+            reportValidationIssue(
                 `\n\n‼️-----‼️ \nAsset Recovery Address mismatch for chain '${chainName}'. \nOn-chain: ${onchainRecoveryAddress} \nCSV:      ${csvRecoveryAddress} \n‼️-----‼️\n\n`,
             );
         }
     }
 }
 
-function generateChainUpdates(onChainState, csvState, chainDetails) {
+function generateChainUpdates(
+    onChainState,
+    csvState,
+    chainDetails,
+    reportValidationIssue,
+) {
     const updates = [];
 
     const currentChainNames = Object.keys(onChainState);
@@ -138,7 +148,7 @@ function generateChainUpdates(onChainState, csvState, chainDetails) {
     // Filter out chains that don't have complete details
     desiredChainNames = desiredChainNames.filter((chainName) => {
         if (!chainDetailsChainNames.includes(chainName)) {
-            console.warn(
+            reportValidationIssue(
                 `\n\n⚠️-----⚠️ \nUnknown chain details in CSV: name='${chainName}' \nInclude chain details to the chain details tab in the Google Sheet to add coverage to it. \n⚠️-----⚠️\n\n`,
             );
             return false;
@@ -212,13 +222,24 @@ function generateChainUpdates(onChainState, csvState, chainDetails) {
     return { updates, chainsToRemove };
 }
 
-export function generateUpdates(onChainState, csvState, chainDetails) {
-    validateRecoveryAddress(onChainState, csvState, chainDetails);
+export function generateUpdates(
+    onChainState,
+    csvState,
+    chainDetails,
+    reportValidationIssue = console.warn,
+) {
+    validateRecoveryAddress(
+        onChainState,
+        csvState,
+        chainDetails,
+        reportValidationIssue,
+    );
 
     const { updates: chainUpdates, chainsToRemove } = generateChainUpdates(
         onChainState,
         csvState,
         chainDetails,
+        reportValidationIssue,
     );
     const accountUpdates = generateAccountUpdates(
         onChainState,

--- a/scripts/safeharbor/src/verifyPayload.js
+++ b/scripts/safeharbor/src/verifyPayload.js
@@ -1,0 +1,18 @@
+export function verifyPayload({ updates, validationIssues }) {
+    const failures = [
+        ...validationIssues,
+        ...updates.map((update) =>
+            JSON.stringify({
+                function: update.function,
+                args: update.args,
+                calldata: update.calldata,
+            }),
+        ),
+    ];
+
+    if (failures.length > 0) {
+        throw new Error(
+            `SafeHarbor verification failed:\n${failures.join("\n")}`,
+        );
+    }
+}

--- a/scripts/safeharbor/test/generatePayload.test.js
+++ b/scripts/safeharbor/test/generatePayload.test.js
@@ -153,6 +153,7 @@ describe("inspectPayload E2E Tests", () => {
             // Assert - should have empty result since no changes needed
             assert.strictEqual(result.updates.length, 0);
             assert.strictEqual(result.solidityCode, "");
+            assert.deepStrictEqual(result.validationIssues, []);
         });
     });
 
@@ -617,7 +618,15 @@ describe("inspectPayload E2E Tests", () => {
             getNormalizedContractsInScopeFromCSV.mockResolvedValue(csvData);
 
             // Act
-            await generatePayload("", false); // No need to return updates
+            const result = await generatePayload("");
+
+            assert.ok(
+                result.validationIssues.some(
+                    (issue) =>
+                        issue.includes("Asset Recovery Address mismatch") &&
+                        issue.includes("ETHEREUM"),
+                ),
+            );
 
             // Assert
             const wasCalledWithMismatchWarning = consoleWarnSpy.mock.calls.some(
@@ -643,7 +652,7 @@ describe("inspectPayload E2E Tests", () => {
             );
         });
 
-        test("should log a warning when unknown chain details are found in on-chain state", async () => {
+        test("should report unknown chain details found in on-chain state", async () => {
             // Arrange
             // Import the actual implementation instead of the mock
             const {
@@ -670,33 +679,56 @@ describe("inspectPayload E2E Tests", () => {
             };
 
             // Act - use the actual implementation
+            const validationIssues = [];
             const result = await actualGetNormalizedDataFromOnchainState(
                 mockAgreementContract,
                 CHAIN_DETAILS,
+                (issue) => validationIssues.push(issue),
             );
 
             // Assert
-            const wasCalledWithUnknownChainWarning =
-                consoleWarnSpy.mock.calls.some(
-                    (call) =>
-                        call[0].includes(
-                            "Unknown chain details in on-chain state",
-                        ) && call[0].includes("caip2ChainId='eip155:999999'"),
-                );
-
             assert.ok(
-                wasCalledWithUnknownChainWarning,
-                "console.warn should be called with a warning about unknown chain in on-chain state",
+                validationIssues.some(
+                    (issue) =>
+                        issue.includes(
+                            "Unknown chain details in on-chain state",
+                        ) && issue.includes("caip2ChainId='eip155:999999'"),
+                ),
+                "unknown on-chain chains should be reported as validation issues",
             );
 
             // Verify that the unknown chain was not included in the result
             assert.ok(!Object.hasOwn(result, "UNKNOWN"));
             assert.ok(Object.hasOwn(result, "ETHEREUM"));
         });
+
+        test("should report unknown chain details found in CSV state", async () => {
+            getNormalizedDataFromOnchainState.mockResolvedValue(
+                INITIAL_ONCHAIN_STATE,
+            );
+            getNormalizedContractsInScopeFromCSV.mockResolvedValue({
+                UNKNOWN: [
+                    {
+                        accountAddress: ACCOUNT.UNKNOWN,
+                        childContractScope: 0,
+                    },
+                ],
+            });
+
+            const result = await generatePayload("");
+
+            assert.ok(
+                result.validationIssues.some(
+                    (issue) =>
+                        issue.includes("Unknown chain details in CSV") &&
+                        issue.includes("UNKNOWN"),
+                ),
+            );
+        });
     });
 
     describe("Chain Details Duplicate Validation", () => {
-        test("should log a warning when duplicate chain names are found in CSV", async () => {
+        test("should report duplicate chain names found in CSV", async () => {
             // Arrange
             // Mock fetch to return CSV data with duplicate chain names
             global.fetch = vi.fn().mockResolvedValue({
@@ -717,29 +749,27 @@ BASE,eip155:8453,${RECOVERY.BASE}`,
                 await vi.importActual("../src/fetchCSV.js");
 
             // Act
+            const validationIssues = [];
             await actualGetChainDetailsFromCSV(
                 "https://example.test/chain-details.csv",
+                (issue) => validationIssues.push(issue),
             );
 
             // Assert
-            const wasCalledWithDuplicateNamesWarning =
-                consoleWarnSpy.mock.calls.some(
-                    (call) =>
-                        call[0].includes(
-                            "⚠️  Warning: Duplicate chain name found in CSV",
-                        ) && call[0].includes("ETHEREUM"),
-                );
-
             assert.ok(
-                wasCalledWithDuplicateNamesWarning,
-                "console.warn should be called with a warning about duplicate chain name",
+                validationIssues.some(
+                    (issue) =>
+                        issue.includes("Duplicate chain name found in CSV") &&
+                        issue.includes("ETHEREUM"),
+                ),
+                "duplicate chain names should be reported as validation issues",
             );
 
             // Clean up
             delete global.fetch;
         });
 
-        test("should log a warning when duplicate chain IDs are found in CSV", async () => {
+        test("should report duplicate chain IDs found in CSV", async () => {
             // Arrange
             // Mock fetch to return CSV data with duplicate chain IDs
             global.fetch = vi.fn().mockResolvedValue({
@@ -760,22 +790,20 @@ BASE,eip155:8453,${RECOVERY.BASE}`,
                 await vi.importActual("../src/fetchCSV.js");
 
             // Act
+            const validationIssues = [];
             await actualGetChainDetailsFromCSV(
                 "https://example.test/chain-details.csv",
+                (issue) => validationIssues.push(issue),
             );
 
             // Assert
-            const wasCalledWithDuplicateChainIdsWarning =
-                consoleWarnSpy.mock.calls.some(
-                    (call) =>
-                        call[0].includes(
-                            "⚠️  Warning: Duplicate chain ID found in CSV",
-                        ) && call[0].includes("eip155:1"),
-                );
-
             assert.ok(
-                wasCalledWithDuplicateChainIdsWarning,
-                "console.warn should be called with a warning about duplicate chain ID",
+                validationIssues.some(
+                    (issue) =>
+                        issue.includes("Duplicate chain ID found in CSV") &&
+                        issue.includes("eip155:1"),
+                ),
+                "duplicate chain IDs should be reported as validation issues",
             );
 
             // Clean up

--- a/scripts/safeharbor/test/verifyPayload.test.js
+++ b/scripts/safeharbor/test/verifyPayload.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { verifyPayload } from "../src/verifyPayload.js";
+
+describe("verifyPayload", () => {
+    test("accepts an empty payload without validation issues", () => {
+        expect(() =>
+            verifyPayload({ updates: [], validationIssues: [] }),
+        ).not.toThrow();
+    });
+
+    test("rejects generated updates", () => {
+        expect(() =>
+            verifyPayload({
+                updates: [
+                    {
+                        function: "addAccounts",
+                        args: ["eip155:1", []],
+                        calldata: "0x1234",
+                    },
+                ],
+                validationIssues: [],
+            }),
+        ).toThrow(/addAccounts/);
+    });
+
+    test("rejects validation issues even when the payload is empty", () => {
+        expect(() =>
+            verifyPayload({
+                updates: [],
+                validationIssues: ["Unknown chain details in CSV: SOLANA"],
+            }),
+        ).toThrow(/Unknown chain details in CSV: SOLANA/);
+    });
+});


### PR DESCRIPTION
## Summary

- add a strict SafeHarbor verification command that fails on generated updates or validation issues
- add an opt-in Tenderly cast target for spells that update SafeHarbor
- dispatch post-cast verification against the public Tenderly VNet from GitHub Actions

## Details

`make cast-on-tenderly` remains unchanged for ordinary spells. `make cast-on-tenderly-safeharbor spell=<address>` requires a clean, pushed branch, casts the spell, publishes the VNet, and asynchronously dispatches the SafeHarbor workflow on that exact branch.

The workflow receives only the public RPC endpoint, spell address, and public explorer URL. Tenderly credentials and the admin RPC endpoint remain local.

The verifier passes only when the live SafeHarbor source data matches the post-cast Agreement state and no validation issue was encountered while reconciling the two.

This PR is stacked on #558. The end-to-end workflow dispatch can run after `safeharbor.yaml` from #558 exists on the default branch.
